### PR TITLE
feat/#7--공통-textfield

### DIFF
--- a/app/components/TextField.stories.ts
+++ b/app/components/TextField.stories.ts
@@ -1,0 +1,38 @@
+import TextField from './TextField';
+import { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof TextField> = {
+  title: 'Components/TextField',
+  component: TextField,
+  argTypes: {
+    type: {
+      control: { type: 'radio' },
+      options: ['box', 'reply'],
+    },
+    placeholder: {
+      control: { type: 'text' },
+    },
+    value: {
+      control: { type: 'text' },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof TextField>;
+
+export const Box: Story = {
+  args: {
+    type: 'box',
+    placeholder: '댓글을 입력해주세요.',
+    value: '',
+  },
+};
+
+export const Reply: Story = {
+  args: {
+    type: 'reply',
+    placeholder: '댓글을 입력해주세요.',
+    value: '',
+  },
+};

--- a/app/components/TextField.tsx
+++ b/app/components/TextField.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import React, { useEffect, useRef } from 'react';
+import styles from '@/app/styles/scrollbar.module.css';
+
+interface TextFieldProps {
+  type: 'box' | 'reply';
+  height?: number;
+  value: string;
+  placeholder?: string;
+  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+}
+
+export default function TextField({
+  type,
+  height,
+  value,
+  placeholder,
+  onChange,
+}: TextFieldProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const baseStyle =
+    'w-full text-primary resize-none font-normal text-t-primary focus:outline-none';
+
+  const typeStyle =
+    type === 'box'
+      ? `border border-[#F8FAFC1A] px-[16px] md:px-[24px] py-[8px] md:py-[16px] text-md md:text-lg leading-26 focus:border-bd-primary border-1px rounded-[12px] bg-b-secondary placeholder-[#9CA3AF] overflow-auto ${styles.customScrollbar}`
+      : 'h-full p-0 text-sm border-none bg-transparent placeholder-t-default';
+
+  // reply 타입 - 내용에 맞게 높이 설정
+  useEffect(() => {
+    if (textareaRef.current && type === 'reply') {
+      textareaRef.current.style.height = '0px';
+      textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
+    }
+  }, [value, type]);
+
+  return (
+    <textarea
+      ref={textareaRef}
+      value={value}
+      placeholder={placeholder}
+      onChange={onChange}
+      className={`${baseStyle} ${typeStyle}`}
+      style={type === 'box' && height ? { height: `${height}px` } : {}}
+    />
+  );
+}

--- a/app/components/TextField.tsx
+++ b/app/components/TextField.tsx
@@ -25,7 +25,7 @@ export default function TextField({
 
   const typeStyle =
     type === 'box'
-      ? `border border-[#F8FAFC1A] px-[16px] md:px-[24px] py-[8px] md:py-[16px] text-md md:text-lg leading-26 focus:border-bd-primary border-1px rounded-[12px] bg-b-secondary placeholder-[#9CA3AF] overflow-auto ${styles.customScrollbar}`
+      ? `border border-[#F8FAFC1A] px-[16px]  sm:px-[24px] py-[8px] sm:py-[16px] text-md sm:text-lg leading-26 focus:border-bd-primary border-1px rounded-[12px] bg-b-secondary placeholder-[#9CA3AF] overflow-auto ${styles.customScrollbar}`
       : 'h-full p-0 text-sm border-none bg-transparent placeholder-t-default';
 
   // reply 타입 - 내용에 맞게 높이 설정

--- a/app/components/TextField.tsx
+++ b/app/components/TextField.tsx
@@ -8,7 +8,7 @@ interface TextFieldProps {
   height?: number;
   value: string;
   placeholder?: string;
-  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
 }
 
 export default function TextField({

--- a/app/styles/scrollbar.module.css
+++ b/app/styles/scrollbar.module.css
@@ -1,0 +1,25 @@
+.customScrollbar {
+  padding-right: 4px;
+  box-sizing: border-box;
+}
+
+.customScrollbar::-webkit-scrollbar {
+  width: 12px;
+  height: 6px;
+}
+
+.customScrollbar::-webkit-scrollbar-track {
+  background: transparent;
+  margin: 4px 0;
+}
+
+.customScrollbar::-webkit-scrollbar-thumb {
+  background-color: #334155;
+  background-clip: padding-box;
+  border: 4px solid transparent;
+  border-radius: 6px;
+}
+
+.customScrollbar::-webkit-scrollbar-thumb:hover {
+  background-color: #94a3b8;
+}


### PR DESCRIPTION
## 📌 Related Issue
- Closed #7

## 🧾 작업 사항
- 공통 TextField 작업을 했습니다
- box 버전과 reply 버전이 있습니다 (피그마 혹은 노션 R&R 참고)
- box 버전은 아래로 작성하면 스크롤이 늘어나고, reply버전은 필드 영역 자체가 아래로 더 생기는 방식입니다
- props:
  - type(필수) : box/reply 선택
  - height(선택): box 쓰는 경우 높이 커스텀
  - value(필수): input값 (부모에서 제어)
  - placeholder(선택)
  - onChange(선택) 선택인데 코드에는 필수로 들어가있네요 수정할게요

## 📚 리뷰 포인트
- 디자인 반영 안 된 부분이 있다면 말씀해주세요!
- 반응형은 우선 모바일 - 태블릿 간 변동되는 부분이 있어서 md로 잡아두었고, breakpoint 논의 후 변경 예정입니다
- reply버전의 textfield를 어디까지 영역으로 볼 것이냐를 조금 고민했는데요
![스크린샷 2025-01-20 오후 12 34 49](https://github.com/user-attachments/assets/73def47c-85b7-4af1-8b92-498caab544ea)
오른쪽 화살표 버튼 영역을 잡아둘까 하다가 에디터 모드가 여러 버전이 있는 것 같아서 딱 글자 들어가는 영역만 잡아두었습니다. 혹시 수정이 필요하다면 말씀해주세요
- 저도 일단 스토리 파일을 components에 넣긴 했는데, stories에 넣는게 맞아 보이기도 합니다.
스토리북은 폰트 설정을 따로 해줘야 해서 적용이 안되어있습니다
중복될 것 같아서 안 넣었는데 테스트 하실 분들은 연학님 작업하신 것처럼 main, preview를 수정해주셔야 합니다
추후에 chromatic으로 pr 생성 시 스토리북이 자동 빌드될 수 있는 것도 연구해볼게요 .. 

## 📷 Screenshot/GIF
- Box버전 / 모바일 / focus
![스크린샷 2025-01-20 오후 12 41 07](https://github.com/user-attachments/assets/6ef22e79-5efd-4497-9760-c8418e275847)
- Box버전 / 태블릿, pc / 스크롤 확인
![스크린샷 2025-01-20 오후 12 50 03](https://github.com/user-attachments/assets/c9bcb1a8-2322-462e-a66e-de593f6eae14)
- reply 버전 / 기본 영역 확인
![스크린샷 2025-01-20 오후 12 49 22](https://github.com/user-attachments/assets/c0557c1f-befc-4707-91d6-5e0bd3486184)
- reply 버전 / 늘어나는 영역 확인
![스크린샷 2025-01-20 오후 12 52 08](https://github.com/user-attachments/assets/0cd01915-543e-4cd1-a851-16bd0a4d5f1c)
