### PR TITLE
feat/#20--공통-Dropdown

### DIFF
--- a/app/components/Dropdown/DropdownButton.tsx
+++ b/app/components/Dropdown/DropdownButton.tsx
@@ -1,0 +1,19 @@
+import React, { ReactNode } from 'react';
+
+interface DropdownButtonProps {
+  children: ReactNode;
+  onClick: () => void;
+}
+
+const DropdownButton = ({ children, onClick }: DropdownButtonProps) => {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default DropdownButton;

--- a/app/components/Dropdown/DropdownButton.tsx
+++ b/app/components/Dropdown/DropdownButton.tsx
@@ -3,13 +3,19 @@ import React, { ReactNode } from 'react';
 interface DropdownButtonProps {
   children: ReactNode;
   onClick: () => void;
+  className?: string;
 }
 
-const DropdownButton = ({ children, onClick }: DropdownButtonProps) => {
+const DropdownButton = ({
+  children,
+  onClick,
+  className,
+}: DropdownButtonProps) => {
   return (
     <button
       type="button"
       onClick={onClick}
+      className={className}
     >
       {children}
     </button>

--- a/app/components/Dropdown/DropdownMenu.module.css
+++ b/app/components/Dropdown/DropdownMenu.module.css
@@ -1,0 +1,65 @@
+/* Entrance: Scale-In */
+.scale-in-tr {
+  transform-origin: top right;
+  -webkit-animation: scale-in-tr 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
+  animation: scale-in-tr 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
+}
+
+@-webkit-keyframes scale-in-tr {
+  0% {
+    transform: scale(0.8) translate(5px, -5px);
+    opacity: 0;
+  }
+  60% {
+    transform: scale(1.1) translate(-3px, 3px);
+    opacity: 0.7;
+  }
+  100% {
+    transform: scale(1) translate(0, 0);
+    opacity: 1;
+  }
+}
+
+@keyframes scale-in-tr {
+  0% {
+    transform: scale(0.8) translate(5px, -5px);
+    opacity: 0;
+  }
+  60% {
+    transform: scale(1.1) translate(-3px, 3px);
+    opacity: 0.7;
+  }
+  100% {
+    transform: scale(1) translate(0, 0);
+    opacity: 1;
+  }
+}
+
+/* Entrance: Slide-In */
+.slide-in-top {
+  -webkit-animation: slide-in-top 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
+  animation: slide-in-top 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
+  z-index: 10;
+}
+
+@-webkit-keyframes slide-in-top {
+  0% {
+    transform: translateY(-30px);
+    opacity: 0;
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes slide-in-top {
+  0% {
+    transform: translateY(-30px);
+    opacity: 0;
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}

--- a/app/components/Dropdown/DropdownMenu.tsx
+++ b/app/components/Dropdown/DropdownMenu.tsx
@@ -1,0 +1,36 @@
+import React, { ReactNode } from 'react';
+import styles from './DropdownMenu.module.css';
+
+interface DropdownMenuProps {
+  children: ReactNode;
+  className?: string;
+  animationType?: 'scale' | 'slide';
+  isOpen: boolean;
+}
+
+const DropdownMenu = ({
+  children,
+  className,
+  animationType,
+  isOpen,
+}: DropdownMenuProps) => {
+  if (!isOpen) return null;
+
+  const animationClasses = {
+    scale: styles['scale-in-tr'],
+    slide: styles['slide-in-top'],
+  };
+
+  const animationClass =
+    (animationType && animationClasses[animationType]) || '';
+
+  return (
+    <div
+      className={`border-b-tertiarytertiary absolute w-[120px] overflow-hidden rounded-[12px] border-[1px] border-[#334155] bg-b-secondary p-[2px] ${className} ${animationClass}`}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default DropdownMenu;

--- a/app/components/Dropdown/DropdownMenuItem.tsx
+++ b/app/components/Dropdown/DropdownMenuItem.tsx
@@ -1,0 +1,19 @@
+import React, { ReactNode } from 'react';
+
+interface DropdownMenuItemProps {
+  children: ReactNode;
+  onClick?: () => void;
+}
+
+const DropdownMenuItem = ({ children, onClick }: DropdownMenuItemProps) => {
+  return (
+    <div
+      className="cursor-pointer rounded-[11px] bg-b-secondary px-[16px] pb-[11px] pt-[12px] text-md transition-colors duration-200 hover:bg-b-tertiary active:scale-95"
+      onClick={onClick}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default DropdownMenuItem;

--- a/app/components/Dropdown/DropdownMenuItem.tsx
+++ b/app/components/Dropdown/DropdownMenuItem.tsx
@@ -7,12 +7,12 @@ interface DropdownMenuItemProps {
 
 const DropdownMenuItem = ({ children, onClick }: DropdownMenuItemProps) => {
   return (
-    <div
-      className="cursor-pointer rounded-[11px] bg-b-secondary px-[16px] pb-[11px] pt-[12px] text-md transition-colors duration-200 hover:bg-b-tertiary active:scale-95"
+    <button
+      className="w-full cursor-pointer rounded-[11px] border-none bg-b-secondary bg-none px-[16px] pb-[11px] pt-[12px] text-md transition-colors duration-200 hover:bg-b-tertiary focus:outline-none active:scale-95"
       onClick={onClick}
     >
       {children}
-    </div>
+    </button>
   );
 };
 

--- a/app/components/Dropdown/index.tsx
+++ b/app/components/Dropdown/index.tsx
@@ -1,0 +1,28 @@
+import React, { ReactNode } from 'react';
+import useClickOutside from '@/app/hooks/useClickOutside';
+import DropdownButton from './DropdownButton';
+import DropdownMenu from './DropdownMenu';
+import DropdownMenuItem from './DropdownMenuItem';
+
+interface DropdownProps {
+  children: ReactNode;
+  onClose: () => void;
+}
+
+export default function Dropdown({ children, onClose }: DropdownProps) {
+  // 외부 클릭 시 닫히도록
+  const ref = useClickOutside(onClose);
+
+  return (
+    <div
+      ref={ref}
+      className="relative"
+    >
+      {children}
+    </div>
+  );
+}
+
+Dropdown.Button = DropdownButton;
+Dropdown.Menu = DropdownMenu;
+Dropdown.MenuItem = DropdownMenuItem;

--- a/app/dummy/dropdown/page.tsx
+++ b/app/dummy/dropdown/page.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import Dropdown from '@/app/components/Dropdown';
+import useToggle from '@/app/hooks/useToggle';
+import Image from 'next/image';
+
+export default function Home() {
+  const dropdown1 = useToggle();
+  const dropdown2 = useToggle();
+
+  return (
+    <div className="h-screen w-full">
+      <div className="container py-8">
+        <h1 className="mb-4 text-2xl font-bold">드롭다운 테스트 페이지</h1>
+
+        <div className="flex gap-32">
+          <Dropdown onClose={dropdown1.setFalse}>
+            <Dropdown.Button onClick={dropdown1.toggle}>
+              <div className="w-[120px] cursor-pointer rounded-[11px] border-[1px] border-white bg-b-primary px-[16px] pb-[11px] pt-[12px] text-md">
+                드롭다운 버튼
+              </div>
+            </Dropdown.Button>
+            {dropdown1.state && (
+              <Dropdown.Menu
+                className="right-0 top-[50px]"
+                isOpen={dropdown1.state}
+                animationType="slide"
+              >
+                <Dropdown.MenuItem onClick={() => alert('한 번 clicked')}>
+                  한 번
+                </Dropdown.MenuItem>
+                <Dropdown.MenuItem onClick={() => alert('매일 clicked')}>
+                  매일
+                </Dropdown.MenuItem>
+                <Dropdown.MenuItem onClick={() => alert('주 반복 clicked')}>
+                  주 반복
+                </Dropdown.MenuItem>
+                <Dropdown.MenuItem onClick={() => alert('월 반복 clicked')}>
+                  월 반복
+                </Dropdown.MenuItem>
+              </Dropdown.Menu>
+            )}
+          </Dropdown>
+          <Dropdown onClose={dropdown2.setFalse}>
+            <Dropdown.Button onClick={dropdown2.toggle}>
+              <Image
+                src="/images/icons/ic_user.svg"
+                alt="드롭다운 이미지 버튼 예시"
+                width={24}
+                height={24}
+              />
+            </Dropdown.Button>
+            {dropdown2.state && (
+              <Dropdown.Menu
+                className="right-0 top-[30px] text-center"
+                isOpen={dropdown2.state}
+                animationType="scale"
+              >
+                <Dropdown.MenuItem
+                  onClick={() => console.log('마이 히스토리 clicked')}
+                >
+                  마이 히스토리
+                </Dropdown.MenuItem>
+                <Dropdown.MenuItem
+                  onClick={() => console.log('계정 설정 clicked')}
+                >
+                  계정 설정
+                </Dropdown.MenuItem>
+                <Dropdown.MenuItem
+                  onClick={() => console.log('팀 참여 clicked')}
+                >
+                  팀 참여
+                </Dropdown.MenuItem>
+                <Dropdown.MenuItem
+                  onClick={() => console.log('로그아웃 clicked')}
+                >
+                  로그아웃
+                </Dropdown.MenuItem>
+              </Dropdown.Menu>
+            )}
+          </Dropdown>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/hooks/useClickOutside.ts
+++ b/app/hooks/useClickOutside.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from 'react';
+
+const useClickOutside = (onClickOutside: () => void) => {
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent | TouchEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        onClickOutside();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('touchstart', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('touchstart', handleClickOutside);
+    };
+  }, [onClickOutside]);
+
+  return ref;
+};
+
+export default useClickOutside;

--- a/app/hooks/useToggle.ts
+++ b/app/hooks/useToggle.ts
@@ -1,0 +1,17 @@
+import { useState, useCallback } from 'react';
+
+const useToggle = (initialValue = false) => {
+  const [state, setState] = useState(initialValue);
+
+  const toggle = useCallback(() => {
+    setState((prev) => !prev);
+  }, []);
+
+  const setTrue = useCallback(() => setState(true), []);
+
+  const setFalse = useCallback(() => setState(false), []);
+
+  return { state, toggle, setTrue, setFalse };
+};
+
+export default useToggle;

--- a/stories/Dropdown.stories.tsx
+++ b/stories/Dropdown.stories.tsx
@@ -1,0 +1,143 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Dropdown from '../app/components/Dropdown';
+import { useState } from 'react';
+
+const meta: Meta<typeof Dropdown> = {
+  title: 'Components/Dropdown',
+  component: Dropdown,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    description: {
+      story: '드롭다운 컴포넌트입니다.',
+    },
+  },
+  argTypes: {},
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Dropdown>;
+
+export const Default: Story = {
+  args: {},
+  render: () => {
+    const DropDownStoryBook = () => {
+      const [isOpen, setIsOpen] = useState(false);
+
+      return (
+        <Dropdown onClose={() => setIsOpen(false)}>
+          <Dropdown.Button onClick={() => setIsOpen(!isOpen)}>
+            드롭다운 버튼
+          </Dropdown.Button>
+          {isOpen && (
+            <Dropdown.Menu
+              className="right-0 top-[30px]"
+              isOpen={isOpen}
+              animationType={undefined}
+            >
+              <Dropdown.MenuItem onClick={() => alert('한 번 clicked')}>
+                한 번
+              </Dropdown.MenuItem>
+              <Dropdown.MenuItem onClick={() => alert('매일 clicked')}>
+                매일
+              </Dropdown.MenuItem>
+              <Dropdown.MenuItem onClick={() => alert('주 반복 clicked')}>
+                주 반복
+              </Dropdown.MenuItem>
+              <Dropdown.MenuItem onClick={() => alert('월 반복 clicked')}>
+                월 반복
+              </Dropdown.MenuItem>
+            </Dropdown.Menu>
+          )}
+        </Dropdown>
+      );
+    };
+
+    return <DropDownStoryBook />;
+  },
+};
+
+export const WithScaleAnimation: Story = {
+  args: {},
+  render: () => {
+    const DropDownStoryBook = () => {
+      const [isOpen, setIsOpen] = useState(true);
+
+      return (
+        <Dropdown onClose={() => setIsOpen(false)}>
+          <Dropdown.Button onClick={() => setIsOpen(!isOpen)}>
+            드롭다운 버튼
+          </Dropdown.Button>
+          {isOpen && (
+            <Dropdown.Menu
+              className="right-0 top-[30px] text-center"
+              isOpen={isOpen}
+              animationType="scale"
+            >
+              <Dropdown.MenuItem
+                onClick={() => console.log('마이 히스토리 clicked')}
+              >
+                마이 히스토리
+              </Dropdown.MenuItem>
+              <Dropdown.MenuItem
+                onClick={() => console.log('계정 설정 clicked')}
+              >
+                계정 설정
+              </Dropdown.MenuItem>
+              <Dropdown.MenuItem onClick={() => console.log('팀 참여 clicked')}>
+                팀 참여
+              </Dropdown.MenuItem>
+              <Dropdown.MenuItem
+                onClick={() => console.log('로그아웃 clicked')}
+              >
+                로그아웃
+              </Dropdown.MenuItem>
+            </Dropdown.Menu>
+          )}
+        </Dropdown>
+      );
+    };
+
+    return <DropDownStoryBook />;
+  },
+};
+
+export const WithSlideAnimation: Story = {
+  args: {},
+  render: () => {
+    const DropDownStoryBook = () => {
+      const [isOpen, setIsOpen] = useState(true);
+
+      return (
+        <Dropdown onClose={() => setIsOpen(false)}>
+          <Dropdown.Button onClick={() => setIsOpen(!isOpen)}>
+            드롭다운 버튼
+          </Dropdown.Button>
+          {isOpen && (
+            <Dropdown.Menu
+              className="left-[-4px] top-[30px]"
+              isOpen={isOpen}
+              animationType="slide"
+            >
+              <Dropdown.MenuItem onClick={() => alert('한 번 clicked')}>
+                한 번
+              </Dropdown.MenuItem>
+              <Dropdown.MenuItem onClick={() => alert('매일 clicked')}>
+                매일
+              </Dropdown.MenuItem>
+              <Dropdown.MenuItem onClick={() => alert('주 반복 clicked')}>
+                주 반복
+              </Dropdown.MenuItem>
+              <Dropdown.MenuItem onClick={() => alert('월 반복 clicked')}>
+                월 반복
+              </Dropdown.MenuItem>
+            </Dropdown.Menu>
+          )}
+        </Dropdown>
+      );
+    };
+
+    return <DropDownStoryBook />;
+  },
+};


### PR DESCRIPTION
## 📌 Related Issue
- Closed #20 

## 🧾 작업 사항
- dropdown 컴포넌트를 작업했습니다
- Button, Menu, MenuItem을 조립해서 사용
- Button, MenuItem은 children을 넣어서 사용
- Menu의 classname에서는 정렬이나 부모 요소에 대한 absolute 위치를 잡아주면 됩니다

## 📚 리뷰 포인트
- 스토리북에도 예제를 작성하긴 했지만 좀 더 명확한 사용을 위해 dummy폴더에 예제를 추가해두었습니다 (deploy preview에서 확인해보세요 /dummy/dropdown)
- 스토리북 예제는 애니메이션 기준입니다
- 사용했을때 포지션과 스타일이 잘 작동할지 확신이 서지 않아서.. 혹시 사용하시다가 이상 있으면 말씀해주세요
- toogle과 외부 클릭 함수를 hook으로 빼두었습니다

(++ 예전에 추천받은 [compound 패턴](https://patterns-dev-kr.github.io/design-patterns/compound-pattern/)으로 작업해보았어요.. 모든 멘토님께서 강조하셨던 headless한 컴포넌트 만들기에 good 입니다 추천 추천)

## 📷 Screenshot/GIF
- 속도가 넘 느리게 잡히네요.. 실제로는 이렇지 않습니다...
- 순서대로 기본 / slide / 뿅..
![화면-기록-2025-01-22-오후-12 06 05](https://github.com/user-attachments/assets/544d60af-198f-4dea-8a8f-f346398a4555)
![화면-기록-2025-01-22-오후-12 07 16](https://github.com/user-attachments/assets/bfe1703b-3a20-4be0-906a-754d637cec5f)
![화면-기록-2025-01-22-오후-12 06 52](https://github.com/user-attachments/assets/15792945-24db-45de-99f6-956dec53c1c0)
![화면 기록 2025-01-22 오후 12 12 09](https://github.com/user-attachments/assets/4f9f1610-114c-4bca-968a-302c92ac61fe)

