### PR TITLE
feat/13--gnb layout 추가 작업(gnb 전역 적용)

### DIFF
--- a/app/components/Gnb/index.tsx
+++ b/app/components/Gnb/index.tsx
@@ -22,7 +22,7 @@ export default function GNB() {
 
   return (
     <>
-      <nav className="sm:py flex h-[60px] w-full items-center justify-between bg-b-secondary px-4 py-3.5 text-lg font-medium sm:px-6 lg:px-[18vw]">
+      <nav className="sm:py fixed left-0 top-0 z-50 flex h-[60px] w-full items-center justify-between bg-b-secondary px-4 py-3.5 text-lg font-medium text-t-primary sm:px-6 lg:px-[18vw]">
         <div className="flex space-x-10">
           <div className="flex items-center gap-4">
             <div
@@ -46,7 +46,7 @@ export default function GNB() {
               />
             </div>
           </div>
-          <div className="hidden items-center space-x-10 text-t-primary sm:flex">
+          <div className="hidden items-center space-x-10 sm:flex">
             <TeamListDropDown />
             <div>자유게시판</div> {/*자유게시판 이동*/}
           </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import siteMetadata from '@/data/siteMetadata';
 import './styles/globals.css';
+import GNB from './components/Gnb';
 
 export const metadata: Metadata = {
   title: {
@@ -17,7 +18,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
-      <body className="scroll-smooth">{children}</body>
+      <body className="scroll-smooth">
+        <div className="pt-[60px]">{children}</div>
+        <GNB />
+      </body>
     </html>
   );
 }

--- a/stories/Gnb/Gnb.stories.tsx
+++ b/stories/Gnb/Gnb.stories.tsx
@@ -3,6 +3,7 @@ import GNB from '@/app/components/Gnb';
 
 const meta: Meta<typeof GNB> = {
   title: 'Components/GNB',
+  tags: ['autodocs'],
   component: GNB,
 };
 
@@ -10,4 +11,4 @@ export default meta;
 
 type Story = StoryObj<typeof GNB>;
 
-export const Default: Story = {};
+export const NavBar: Story = {};


### PR DESCRIPTION
## 📌 Related Issue
- Closed #13 

## 🧾 작업 사항
- gnb가 모든 페이지에 적용되도록 `layout.tsx` 파일에 추가했습니다.

## 📚 리뷰 포인트
- 스토리를 어떻게 구상해야 할 지 아직 잘 모르겠어서  우선 `docs` 추가해뒀습니다. 추후 고쳐보겠습니다!
- 현재 gnb 컴포넌트엔 현재 페이지를 인식해 메뉴를 다르게 보여주는 설정이 되어있지 않습니다. 우선 여기까지만 현재 브랜치에서 진행하고, 조건 확인에 대한 부분은 브랜치를 생성해 작업하겠습니다.


## 📷 Screenshot/GIF

![image](https://github.com/user-attachments/assets/44ad3437-cb15-4bda-9579-01201b7ca1ec)
