### PR TITLE
fix/48 zustand 스토어 Hydration 오류 해결

### DIFF
--- a/app/libs/axios.ts
+++ b/app/libs/axios.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import useUserStore from '../stores/userStore';
 
 const instance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_URL,
@@ -8,46 +9,88 @@ const instance = axios.create({
   timeout: 10000, // 요청 타임아웃 설정 (10초)
 });
 
+// 토큰 갱신 함수
+const refreshAccessToken = async (): Promise<string | null> => {
+  const { refreshToken, clearUser, setAccessToken } = useUserStore.getState();
+
+  if (!refreshToken) {
+    console.warn('리프레쉬 토큰이 없습니다. 로그아웃 처리합니다.');
+    clearUser();
+    window.location.href = '/login';
+
+    return null;
+  }
+
+  try {
+    const response = await axios.post(
+      `${process.env.NEXT_PUBLIC_BASE_URL}/auth/refresh-token`,
+      { refreshToken }
+    );
+
+    const { accessToken } = response.data;
+    setAccessToken(accessToken); // 새로운 액세스 토큰 저장
+
+    return accessToken;
+  } catch (error) {
+    console.error('토큰 갱신 실패:', error);
+    alert('인증이 만료되었습니다. 다시 로그인해주세요.');
+    clearUser(); // 상태 초기화
+    window.location.href = '/login'; // 로그인 페이지로 리다이렉트
+
+    return null;
+  }
+};
+
+// 요청 인터셉터
 instance.interceptors.request.use(
   (config) => {
-    // 브라우저 환경인지 확인 (SSR 방어 코드)
     if (typeof window !== 'undefined') {
-      const token = localStorage.getItem('access_token');
-      if (token) {
-        config.headers.Authorization = `Bearer ${token}`;
+      const { accessToken } = useUserStore.getState();
+      if (accessToken) {
+        config.headers.Authorization = `Bearer ${accessToken}`;
       }
     }
+
     return config;
   },
   (error) => {
     console.error('Request Error:', error);
+
     return Promise.reject(error);
   }
 );
 
+// 응답 인터셉터
 instance.interceptors.response.use(
-  (response) => {
-    return response;
-  },
-  (error) => {
-    const status = error.response?.status;
+  (response) => response,
+  async (error) => {
+    const { response, config } = error;
+    const status = response?.status;
 
+    // 인증 실패: 토큰 만료 가능성
     if (status === 401) {
-      // 인증 실패 처리 (로그인 페이지로 리다이렉트)
-      console.error('인증 정보가 없습니다. 로그인 페이지로 이동합니다.');
-      window.location.href = '/login';
+      const originalRequest = config;
+
+      if (!originalRequest._retry) {
+        originalRequest._retry = true; // 재시도 플래그 설정
+
+        const newAccessToken = await refreshAccessToken();
+        if (newAccessToken) {
+          originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+
+          return instance(originalRequest); // 새 토큰으로 요청 재시도
+        }
+      }
     } else if (status === 403) {
-      // 권한 없음
       console.error('권한이 없습니다. 관리자에게 문의하세요.');
     } else if (status === 500) {
-      // 서버 에러
       console.error('서버 에러가 발생했습니다. 잠시 후 다시 시도하세요.');
+    } else if (!response) {
+      console.error('네트워크 에러 또는 서버와의 연결이 끊어졌습니다.');
     } else {
-      // 기타 에러
-      console.error(`Error ${status}:`, error.response?.data || error.message);
+      console.error(`Error ${status}:`, response?.data || error.message);
     }
 
-    // 에러를 그대로 다음 핸들러로 전달
     return Promise.reject(error);
   }
 );

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -9,13 +9,14 @@ import { authResponseType, LoginformDataType } from '../types/auth';
 import axios from 'axios';
 
 export default function LoginPage() {
-  const { setToken, setUser } = useUserStore();
+  const { setAccessToken, setRefreshToken, setUser } = useUserStore();
 
   const loginMutation = useMutation({
     mutationFn: postAuthSignIn,
     onSuccess: (data: authResponseType['postAuthSignIn']) => {
-      const { accessToken, user } = data;
-      setToken(accessToken);
+      const { user, accessToken, refreshToken } = data;
+      setAccessToken(accessToken);
+      setRefreshToken(refreshToken);
       setUser(user);
       alert('로그인에 성공했습니다!');
     },

--- a/app/stores/teamStore.ts
+++ b/app/stores/teamStore.ts
@@ -1,33 +1,49 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 interface Team {
-  id: string;
+  teamId: string;
+  updatedAt: string;
+  createdAt: string;
+  image: string;
   name: string;
+  id: number;
 }
 
 interface TeamState {
   teamList: Team[];
   currentTeam: Team | null;
   setTeamList: (teams: Team[]) => void; // 팀 목록을 설정하는 함수
-  setCurrentTeam: (teamId: string) => void; // 현재 선택된 팀을 설정하는 함수
+  setCurrentTeam: (teamId: number) => void; // 현재 선택된 팀을 설정하는 함수
 }
 
-const useTeamStore = create<TeamState>((set, get) => ({
-  teamList: [],
-  currentTeam: null,
+const useTeamStore = create<TeamState>()(
+  persist(
+    (set, get) => ({
+      teamList: [],
+      currentTeam: null,
 
-  setTeamList: (teams) => set({ teamList: teams }),
-  // 팀 목록을 상태에 저장하는 함수
+      setTeamList: (teams) => set({ teamList: teams }),
+      // 팀 목록을 상태에 저장하는 함수
 
-  setCurrentTeam: (teamId) => {
-    // 팀 ID를 기반으로 현재 팀을 설정하는 함수
-    const selectedTeam = get().teamList.find((team) => team.id === teamId);
-    // 팀 목록에서 주어진 ID와 일치하는 팀을 찾음
-
-    set({ currentTeam: selectedTeam || null });
-    // 찾은 팀을 상태의 currentTeam에 저장, 없으면 null로 설정
-  },
-}));
+      setCurrentTeam: (currentTeamId) => {
+        // 팀 ID를 기반으로 현재 팀을 설정하는 함수
+        const selectedTeam = get().teamList.find(
+          (team) => team.id === currentTeamId
+        );
+        set({ currentTeam: selectedTeam || null });
+      },
+    }),
+    {
+      name: 'team-storage', // 로컬 스토리지에 저장될 키 이름
+      partialize: (state) => ({
+        // 로컬 스토리지에 저장할 상태 선택
+        teamList: state.teamList,
+        currentTeam: state.currentTeam,
+      }),
+    }
+  )
+);
 
 export default useTeamStore;
 

--- a/app/stores/userStore.ts
+++ b/app/stores/userStore.ts
@@ -1,43 +1,43 @@
-import { create } from 'zustand';
+'use client';
 
-interface UserState {
-  user: { nickname: string; email: string } | null; // 사용자 정보 (이름과 이메일)
-  accessToken: string | null; // 인증 토큰
-  setUser: (user: { nickname: string; email: string }) => void; // 사용자 정보를 설정
-  setToken: (token: string) => void; // 인증 토큰을 설정하는 함수
-  clearUser: () => void; // 사용자 정보를 초기화하는 함수
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface UserInfo {
+  id: number;
+  nickname: string;
+  email: string;
+  createdAt: string;
+  updatedAt: string;
+  teamId: string;
 }
 
-const useUserStore = create<UserState>((set) => ({
-  user: null, // 초기 사용자 정보는 null
-  accessToken:
-    typeof window !== 'undefined'
-      ? localStorage.getItem('coworkers_access_token')
-      : null,
-  // 초기 인증 토큰 설정: 클라이언트 환경에서 localStorage에서 가져옴
+interface UserState {
+  user: UserInfo | null;
+  accessToken: string | null; // 액세스 토큰
+  refreshToken: string | null; // 리프레쉬 토큰 추가
+  setUser: (user: UserInfo) => void; // 사용자 정보를 설정
+  setAccessToken: (accessToken: string) => void; // 엑세스 토큰 설정
+  setRefreshToken: (refreshToken: string) => void; // 리프레쉬 토큰 설정
+  clearUser: () => void; // 사용자 정보와 토큰을 초기화
+}
 
-  setUser: (user) => set({ user }),
-  // 사용자 정보를 상태에 저장하는 함수
-
-  setToken: (token) => {
-    if (token) {
-      // 토큰이 존재하면 localStorage에 저장
-      localStorage.setItem('coworkers_access_token', token);
-    } else {
-      // 토큰이 없으면 localStorage에서 삭제
-      localStorage.removeItem('coworkers_access_token');
+const useUserStore = create<UserState>()(
+  persist(
+    (set) => ({
+      user: null,
+      accessToken: null,
+      refreshToken: null, // 초기값 추가
+      setUser: (user) => set({ user }),
+      setAccessToken: (accessToken) => set({ accessToken }),
+      setRefreshToken: (refreshToken) => set({ refreshToken }),
+      clearUser: () =>
+        set({ user: null, accessToken: null, refreshToken: null }), // 초기화
+    }),
+    {
+      name: 'coworkers-storage', // 로컬 스토리지 키
     }
-    set({ accessToken: token }); // 상태에 토큰 업데이트
-  },
-
-  clearUser: () => {
-    // 사용자 정보를 초기화하는 함수
-    localStorage.removeItem('coworkers_access_token'); // localStorage에서 토큰 삭제
-    set({ user: null, accessToken: null }); // 상태 초기화
-  },
-}));
+  )
+);
 
 export default useUserStore;
-
-// 사용 예시
-// const { user, token, setUser, setToken, clearUser } = useUserStore();


### PR DESCRIPTION
## 📌 Related Issue
- Closed #48 

## 🚑️ 발생한 문제
- `zustand`를 사용해 로그인 직후 토큰이 정상적으로 저장되어도, 클라이언트에서만 동작하는 `zustand`의 특성상 페이지 이동 또는 새로고침 시 저장소가 초기화되어 스토어로 토큰을 가져올 수 없는 오류.

## 🧾 작업 사항
- 각 `store`에 `persist` 미들웨어를 적용하여 페이지가 언마운트/리마운트 되어도 로컬 스토리지의 데이터를 동기화 할 수 있도록 로직 수정
- `useUserStore` 에 데이터 추가
  - `refreshToken`
  - `user` 데이터(`id`, `createdAt`, `updatedAt`)
- `libs/axios.ts` 인터셉터 파일에 리프레쉬 로직 추가
  - api 요청 시 401에러(인증)가 발생하면 `refreshAccessToken` 함수를 실행
  - 갱신 실패 시 재 로그인 요청
- `loginPage` 토큰 저장 로직에 스토어 변경사항 반영

## 📚 리뷰 포인트
- `persist`를 사용하여 이제 로컬 스토리지엔 'coworkers-storage`라는 키로 저장소가 생성됩니다. 데이터 요청 시 zustand에서 자동으로 스토어 내의 정보를 가져오므로 `use____Store`를 사용해주시면 로컬 스토리지에 직접 접근하시는 경우는 아마 없을 겁니다.


++ 정보 공유

저희 서버의 토큰 만료 시간은 **1시간**입니다!
리프레쉬 테스트 방법을 찾다가 만료 시간을 알 수 없나 찾아보니, 토큰에 만료 시간이 인코딩되어있다는 것을 알 수 있었습니다.(강의 내용에 있었다는 것 같은데 전 기억이 안 나네요 ㅎㅎ)

아래 코드에 토큰을 입력해 실행하면 콘솔에 만료 시간이 나오더군요
```js
const token = "aaaaa";  // 엑세스 토큰 데이터

// Base64로 디코딩
const base64Url = token.split('.')[1]; // 페이로드 부분 추출
const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/'); // Base64 URL-safe 변환
const payload = JSON.parse(atob(base64)); // 디코딩 후 JSON 파싱

console.log('Payload:', payload);
console.log('만료 시간 (exp):', new Date(payload.exp * 1000)); // 유닉스 타임스탬프를 Date로 변환
```

혹시 모르시는 분들은 신기해 하실 것 같아 공유합니다.