### PR TITLE
fix/#92--myhistory-빌드에러

### DIFF
--- a/app/myhistory/page.tsx
+++ b/app/myhistory/page.tsx
@@ -21,18 +21,25 @@ export default function MyHistoryPage() {
 
   // 데이터 가공
   const groupedTasksByDate = useMemo(() => {
-    if (!userHistory?.tasksDone?.length) return [];
+    if (
+      !Array.isArray(userHistory?.tasksDone) ||
+      userHistory?.tasksDone?.length === 0
+    )
+      return [];
 
     // 시간순 정렬
-    const sortedTasks = [...userHistory.tasksDone].sort(
-      (a, b) => new Date(a.doneAt).getTime() - new Date(b.doneAt).getTime()
-    );
+    const sortedTasks = [...userHistory.tasksDone].sort((a, b) => {
+      return (
+        (a.doneAt ? new Date(a.doneAt).getTime() : 0) -
+        (b.doneAt ? new Date(b.doneAt).getTime() : 0)
+      );
+    });
 
     // 날짜별로 묶기
     const initialAcc: Record<string, { name: string; id: number }[]> = {};
 
     const groupedTasks = sortedTasks.reduce((acc, task) => {
-      const doneDate = task.doneAt.split('T')[0];
+      const doneDate = task.doneAt ? task.doneAt.split('T')[0] : '';
 
       if (!acc[doneDate]) acc[doneDate] = [];
       acc[doneDate].push({ name: task.name, id: task.id });


### PR DESCRIPTION
## 📌 Related Issue
- Closed #92

## 🧾 작업 사항
- 런타임에서 발생한 null 타입 에러를 수정했습니다

## 📚 리뷰 포인트
- null체크가 빠진 부분이 있을지.. 확인 부탁드리겠습니다
- 처음 작업한 브랜치에서는 빌드에러가 나지 않고, netlify검사도 잘 통과해서 문제 없다고 생각했는데, 앞으로는 런타임 에러도 꼭 고려하도록 하겠습니다..!

- 어떻게 없던 에러가 생겼지.. 고민하다가 에러가 발생한 원인을 찾았습니다! 
리스트 상세 페이지에서 type이 doneAt: string;에서 doneAt: string | null; 으로 변경된 부분이 반영되지 않아서 에러가 났었네욥.. 
아마 처음엔 doneAt이 무조건 string이어서 null처리를 안해줬나봐요..
제가 리팩토링 코드를 push하고 머지하는 시점 사이에 리스트상세페이지가 머지되어서 그 사이의 dev를 받아오지 않아서 생긴 문제였습니다 ㅎ ㅎ
리뷰하면서 제 코드에 반영되는 부분은 인지하고 있어야 했는데, 앞으로는 더 꼼꼼히 확인할게요