### PR TITLE
Feat/#98 팀페이지 할 일 목록 추가 기능

### DIFF
--- a/app/[teamid]/TaskLists.tsx
+++ b/app/[teamid]/TaskLists.tsx
@@ -75,9 +75,10 @@ export default function TaskLists({ groupId, taskLists = [] }: Props) {
           </p>
         ) : (
           <ul>
-            {taskLists.map((taskList) => (
+            {taskLists.map((taskList, index) => (
               <TaskListsItem
                 key={taskList.id}
+                index={index}
                 {...taskList}
               />
             ))}

--- a/app/[teamid]/TaskListsItem.tsx
+++ b/app/[teamid]/TaskListsItem.tsx
@@ -5,11 +5,14 @@ import { cn } from '../libs/utils';
 import type { TaskListProps } from './TaskLists';
 import TaskProgress from './TaskProgress';
 
-import PencelIcon from '../components/icons/PencilIcon';
+import KebabIcon from '../components/icons/KebabIcon';
 import styles from './teampage.module.css';
+import Dropdown from '../components/Dropdown';
 
 interface Props extends TaskListProps {
   index: number;
+  onEdit?: (id: number) => void;
+  onDelete?: (id: number) => void;
 }
 
 // 목록 왼쪽 보더 색상값들
@@ -22,13 +25,18 @@ export default function TaskListsItem({
   name,
   tasks,
   onEdit,
+  onDelete,
 }: Props) {
   const borderColor = 'border-' + COLORS[index % COLORS.length];
   const done = tasks.filter((task) => task.doneAt !== null);
 
   // 수정 클릭 함수
-  const handleClick = () => {
+  const handleEditClick = () => {
     if (onEdit) onEdit(id);
+  };
+
+  const handleDeleteClick = () => {
+    if (onDelete) onDelete(id);
   };
 
   return (
@@ -49,13 +57,25 @@ export default function TaskListsItem({
         />
       </span>
 
-      <button
+      <Dropdown>
+        <Dropdown.Button className={styles.iconButton}>
+          <KebabIcon classname="size-3 mx-auto" />
+        </Dropdown.Button>
+        <Dropdown.Menu className="right-0">
+          <Dropdown.MenuItem onClick={handleEditClick}>수정</Dropdown.MenuItem>
+          <Dropdown.MenuItem onClick={handleDeleteClick}>
+            삭제
+          </Dropdown.MenuItem>
+        </Dropdown.Menu>
+      </Dropdown>
+
+      {/* <button
         className={cn(styles.iconButton, 'tool-tip')}
         onClick={handleClick}
         aria-label="할 일 목록 수정"
       >
-        <PencelIcon classname="size-3 mx-auto" />
-      </button>
+        
+      </button> */}
     </li>
   );
 }

--- a/app/[teamid]/TaskListsItem.tsx
+++ b/app/[teamid]/TaskListsItem.tsx
@@ -8,17 +8,21 @@ import TaskProgress from './TaskProgress';
 import KebabIcon from '../components/icons/KebabIcon';
 import styles from './teampage.module.css';
 
+interface Props extends TaskListProps {
+  index: number;
+}
+
 // 목록 왼쪽 보더 색상값들
 const COLORS = ['purple', 'blue', 'cyan', 'pink', 'rose', 'orange', 'yellow'];
 
 export default function TaskListsItem({
   id,
+  index,
   groupId,
   name,
-  displayIndex,
   tasks,
-}: TaskListProps) {
-  const borderColor = 'border-' + COLORS[displayIndex % COLORS.length];
+}: Props) {
+  const borderColor = 'border-' + COLORS[index % COLORS.length];
   const done = tasks.filter((task) => task.doneAt !== null);
 
   return (

--- a/app/[teamid]/modify/page.tsx
+++ b/app/[teamid]/modify/page.tsx
@@ -1,17 +1,18 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-
-import InputField from '../../components/InputField';
-import ImageUpload from '../../components/ImageUpload';
-import Button from '../../components/Button';
-
-import styles from '../../styles/team.module.css';
 import { useParams, useRouter } from 'next/navigation';
 import { useMutation, useQuery } from '@tanstack/react-query';
+
 import { getGroups, patchGroups } from '@/app/api/group.api';
-import Loading from '@/app/components/Loading';
 import useTeamStore from '@/app/stores/teamStore';
+
+import InputField from '@/app/components/InputField';
+import ImageUpload from '@/app/components/ImageUpload';
+import Button from '@/app/components/Button';
+import Loading from '@/app/components/Loading';
+
+import styles from '../../styles/team.module.css';
 
 const MIN_NAME_LENGTH = 2;
 
@@ -44,7 +45,7 @@ export default function ModifyTeamPage() {
     onSuccess: (data) => {
       // TODO: 토스로 변경
       alert('팀 정보를 수정하였습니다.');
-      console.log('--- patchGroups:data:', data);
+      // console.log('--- patchGroups:data:', data);
       router.push(`/${data.id}`);
     },
     onError: (err) => {
@@ -76,7 +77,7 @@ export default function ModifyTeamPage() {
   };
 
   const handleImageUploadSuccess = (url: string) => {
-    console.log('--- handleImageUploadSuccess:', url);
+    // console.log('--- handleImageUploadSuccess:', url);
     setImage(url);
   };
 
@@ -86,8 +87,10 @@ export default function ModifyTeamPage() {
   };
 
   useEffect(() => {
-    setName(group?.name ?? '');
-    setImage(group?.image ?? '');
+    if (group) {
+      setName(group.name);
+      setImage(group.image);
+    }
   }, [group]);
 
   if (isLoading) {
@@ -99,6 +102,8 @@ export default function ModifyTeamPage() {
   }
 
   if (isError) {
+    alert('팀 정보 가져오는데 실패 하였습니다. 잠시 후 다시 시도해 주세요.');
+    router.back();
     return null;
   }
 

--- a/app/[teamid]/page.tsx
+++ b/app/[teamid]/page.tsx
@@ -26,6 +26,7 @@ export default function TeamPage() {
   const [totalTasks, setTotalTasks] = useState(0);
   const [completedTasks, setCompletedTasks] = useState(0);
   const [deleteModal, setDeleteModal] = useState(false);
+  const [incorrectModal, setIncorrectModal] = useState(false);
 
   const { user } = useUserStore();
   const router = useRouter();
@@ -48,8 +49,7 @@ export default function TeamPage() {
       if (member) {
         setRole(member.role);
       } else {
-        alert('접근 가능한 팀이 아닙니다. 다시 확인 부탁드립니다.');
-        router.replace('/');
+        setIncorrectModal(true);
       }
 
       // 할 일 전체와 완료된 할 일 갯수 받기
@@ -65,6 +65,11 @@ export default function TeamPage() {
       setCompletedTasks(complete);
     }
   }, [group, user, router]);
+
+  // 그룹 이미지를 배경 이미지로
+  const bgImage = group?.image
+    ? { backgroundImage: `url(${group.image})` }
+    : {};
 
   // 팀 수정하기 버튼 클릭 함수
   const handleModifyClick = () => {
@@ -85,6 +90,11 @@ export default function TeamPage() {
     }
   };
 
+  // 팀 검증 실패 모달에서 메인페이지로 이동시킴
+  const handleIncorrectModalClose = () => {
+    router.replace('/');
+  };
+
   if (isLoading) {
     return (
       <div className="mt-48">
@@ -100,12 +110,38 @@ export default function TeamPage() {
     return null;
   }
 
+  // 팀 검증 실패 모달
+  if (incorrectModal) {
+    return (
+      <Modal
+        isOpen={incorrectModal}
+        onClose={handleIncorrectModalClose}
+        hasCloseButton={false}
+        icon="danger"
+        title="해당 팀의 멤버가 아닙니다."
+      >
+        <p className="text-center">메인페이지로 돌아갑니다.</p>
+        <ModalFooter>
+          <Button
+            state="danger"
+            onClick={handleIncorrectModalClose}
+          >
+            확인
+          </Button>
+        </ModalFooter>
+      </Modal>
+    );
+  }
+
   if (!group) return null;
 
   return (
     <div className="container flex flex-col py-6">
-      <header className={styles.header}>
-        <h1 className="text-xl font-bold text-t-inverse">
+      <header
+        className={styles.header}
+        style={bgImage}
+      >
+        <h1 className={styles.headerTitle}>
           {group.name}({group.id})
         </h1>
 
@@ -157,7 +193,7 @@ export default function TeamPage() {
             styleType="outlined-secondary"
             onClick={() => setDeleteModal(false)}
           >
-            닫기
+            취소
           </Button>
 
           <Button

--- a/app/[teamid]/teampage.module.css
+++ b/app/[teamid]/teampage.module.css
@@ -5,7 +5,12 @@
 }
 
 .header {
-  @apply flex items-center justify-between rounded-xl border border-bd-primary bg-slate-50/10 bg-[url('/images/bg-team-header.svg')] bg-contain bg-[center_right_80px] bg-no-repeat px-6 py-5;
+  @apply flex items-center justify-between rounded-xl border border-bd-primary bg-slate-50/10 bg-[url('/images/bg-team-header.svg')] bg-clip-padding bg-[center_right_80px] bg-no-repeat px-6 py-5;
+  background-size: 180px auto;
+
+  .headerTitle {
+    @apply text-xl font-bold text-t-inverse;
+  }
 }
 .progress {
   @apply flex items-center gap-1 rounded-xl bg-b-primary px-2 py-1 text-md text-primary;
@@ -14,7 +19,7 @@
   @apply mt-4 flex items-center rounded-xl border-l-[12px] bg-b-secondary p-3;
 }
 .iconButton {
-  @apply ml-1 size-6 rounded-full p-1 text-ic-primary transition-colors hover:bg-b-tertiary hover:text-ic-inverse;
+  @apply ml-2 size-6 rounded-full p-1 text-ic-primary transition-colors hover:bg-b-tertiary hover:text-ic-inverse;
 }
 
 .section {

--- a/app/addteam/page.tsx
+++ b/app/addteam/page.tsx
@@ -27,7 +27,10 @@ export default function AddTeamPage() {
   const validName = name.trim().length >= MIN_NAME_LENGTH;
 
   const { mutate } = useMutation({
-    mutationFn: async () => await postGroups({ image, name }),
+    mutationFn: async () => {
+      if (!image) return await postGroups({ name });
+      else return await postGroups({ name, image });
+    },
     onSuccess: (data) => {
       // TODO: 토스로 변경
       alert('팀을 생성하였습니다.');

--- a/app/components/Dropdown/index.tsx
+++ b/app/components/Dropdown/index.tsx
@@ -24,7 +24,7 @@ export default function Dropdown({ children, className }: DropdownProps) {
 
   // 외부 클릭 시 닫히도록
   const ref = useClickOutside(closeDropdown);
-  console.log('Dropdown children:', children);
+  // console.log('Dropdown children:', children);
 
   return (
     <div


### PR DESCRIPTION
## 📌 Related Issue
- Closed #98 

## 🧾 작업 사항
- 색상 출력을 위한 인덱스 변경
- 팀 생성이나 수정시 이미지 없을때 오류 수정
- 할 일 목록 추가 기능(수정, 삭제) 작업
- 팀 검증 실패 모달로 변경
- 팀 이미지 배경으로

## 📚 리뷰 포인트
- 팀 이미지 배경으로 넣은거 여러 방향으로 수정해 봤는데 더 이뿌게 고치는데 실패했습니다.
- 그래서 우선은 그대로를 넣어놨습니다. 더 이뿌게 넣기위한 아이디어가 필요합니다!!

## 📷 Screenshot/GIF
![image](https://github.com/user-attachments/assets/71fc1e4f-a42b-4758-8152-2c6570f626dd)
![image](https://github.com/user-attachments/assets/45ead898-b36c-4149-b1c2-9e8fc0c96ba1)
![image](https://github.com/user-attachments/assets/2c5f6684-5c6e-43b2-8e7b-5d22dc48eb49)

