### PR TITLE
Feat/90  gnb 기능개선 및 추가 (드롭다온 동기화 오류 및 ui개선)

### DIFF
--- a/app/[teamid]/page.tsx
+++ b/app/[teamid]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { getGroups, deleteGroups } from '../api/group.api';
 import useUserStore from '../stores/userStore';
@@ -18,6 +18,7 @@ import Loading from '../components/Loading';
 
 import GearIcon from '../components/icons/GearIcon';
 import styles from './teampage.module.css';
+import useTeamStore from '../stores/teamStore';
 
 export default function TeamPage() {
   const { teamid } = useParams();
@@ -28,7 +29,10 @@ export default function TeamPage() {
   const [deleteModal, setDeleteModal] = useState(false);
 
   const { user } = useUserStore();
+  const { teamList, setCurrentTeam } = useTeamStore();
+
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   const {
     data: group,
@@ -80,6 +84,11 @@ export default function TeamPage() {
   const handleRealDeleteClick = async () => {
     if (group) {
       const result = await deleteGroups({ groupId: group.id });
+      queryClient.invalidateQueries({
+        queryKey: ['coworkers-teamList', user?.id],
+      });
+      setCurrentTeam(teamList[0].id);
+
       console.log('--- deleteGroups:result:', result);
       router.replace('/');
     }

--- a/app/addteam/page.tsx
+++ b/app/addteam/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { postGroups } from '../api/group.api';
 import useTeamStore from '../stores/teamStore';
@@ -12,6 +12,7 @@ import ImageUpload from '../components/ImageUpload';
 import Button from '../components/Button';
 
 import styles from '../styles/team.module.css';
+import useUserStore from '../stores/userStore';
 
 const MIN_NAME_LENGTH = 2;
 
@@ -21,16 +22,24 @@ export default function AddTeamPage() {
   const [imageErrorMessage, setImageErrorMessage] = useState('');
   const [nameErrorMessage, setNameErrorMessage] = useState('');
   const router = useRouter();
+  const { user } = useUserStore();
   const { teamList } = useTeamStore();
 
   // 최소 2글자 이상인지 확인
   const validName = name.trim().length >= MIN_NAME_LENGTH;
 
+  const queryClient = useQueryClient();
+
   const { mutate } = useMutation({
     mutationFn: async () => await postGroups({ image, name }),
     onSuccess: (data) => {
+      queryClient.invalidateQueries({
+        queryKey: ['coworkers-teamList', user?.id],
+      });
+
       // TODO: 토스로 변경
       alert('팀을 생성하였습니다.');
+
       router.push(`/${data.id}`);
     },
     onError: (err) => {

--- a/app/components/Gnb/ProfileDropDown.tsx
+++ b/app/components/Gnb/ProfileDropDown.tsx
@@ -11,7 +11,8 @@ interface ProfileDropDownProps {
   user: UserType;
 }
 
-const dropDownItemStyle = 'text-md sm:text-lg pt-2 px-4 pb-2';
+const dropDownItemStyle = 'block px-[16px] py-3 text-md sm:text-lg';
+const linkStyle = 'px-[0] pb-[0px] pt-[0px]';
 
 export default function ProfileDropDown({ user }: ProfileDropDownProps) {
   const { clearUser } = useUserStore();
@@ -40,29 +41,44 @@ export default function ProfileDropDown({ user }: ProfileDropDownProps) {
         className="right-0 w-[140px] p-[8px] py-[12px] sm:w-[152px]"
         animationType="scale"
       >
-        <Link href="/myhistory">
-          <Dropdown.MenuItem className={dropDownItemStyle}>
+        <Dropdown.MenuItem className={dropDownItemStyle}>
+          <Link
+            href="/myhistory"
+            className={linkStyle}
+          >
             마이 히스토리
-          </Dropdown.MenuItem>
-        </Link>
-        <Link href="/mypage">
-          <Dropdown.MenuItem className={dropDownItemStyle}>
+          </Link>
+        </Dropdown.MenuItem>
+
+        <Dropdown.MenuItem className={dropDownItemStyle}>
+          <Link
+            href="/mypage"
+            className={linkStyle}
+          >
             계정 설정
-          </Dropdown.MenuItem>
-        </Link>
-        <Link href="/invitation">
-          <Dropdown.MenuItem className={dropDownItemStyle}>
+          </Link>
+        </Dropdown.MenuItem>
+
+        <Dropdown.MenuItem className={dropDownItemStyle}>
+          <Link
+            href="/invitation"
+            className={linkStyle}
+          >
             팀 참여
-          </Dropdown.MenuItem>
-        </Link>
-        <Link href="/">
-          <Dropdown.MenuItem
-            className={dropDownItemStyle}
-            onClick={handleLogout}
+          </Link>
+        </Dropdown.MenuItem>
+
+        <Dropdown.MenuItem
+          className={dropDownItemStyle}
+          onClick={handleLogout}
+        >
+          <Link
+            href="/"
+            className={linkStyle}
           >
             로그아웃
-          </Dropdown.MenuItem>
-        </Link>
+          </Link>
+        </Dropdown.MenuItem>
       </Dropdown.Menu>
     </Dropdown>
   );

--- a/app/components/Gnb/TeamListDropDown.tsx
+++ b/app/components/Gnb/TeamListDropDown.tsx
@@ -18,7 +18,9 @@ export default function TeamListDropDown({
   return (
     <Dropdown>
       <Dropdown.Button className="flex items-center gap-2">
-        {currentTeam?.name || '팀 목록'}
+        <p className="sm:max-w-[206px] sm:truncate lg:max-w-full">
+          {currentTeam?.name || '팀 목록'}
+        </p>
         <Image
           src="/images/icons/ic_dropdown-check.svg"
           alt=""

--- a/app/components/Gnb/TeamListDropDown.tsx
+++ b/app/components/Gnb/TeamListDropDown.tsx
@@ -31,18 +31,20 @@ export default function TeamListDropDown({
         animationType="scale"
         className="top-[52px] z-30 w-[218px] p-[8px] pb-4 sm:-left-[144px] lg:-left-[200px]"
       >
-        {teamList.map((team) => {
-          return (
-            <Link
-              href={`/${team.id}`}
-              key={team.id}
-            >
-              <Dropdown.MenuItem className="pb-[8px] pt-2">
-                <TeamListDropDownItem team={team} />
-              </Dropdown.MenuItem>
-            </Link>
-          );
-        })}
+        {[...teamList]
+          .sort((a, b) => b.id - a.id) // id순 내림차순 정렬
+          .map((team) => {
+            return (
+              <Link
+                href={`/${team.id}`}
+                key={team.id}
+              >
+                <Dropdown.MenuItem className="pb-[8px] pt-2">
+                  <TeamListDropDownItem team={team} />
+                </Dropdown.MenuItem>
+              </Link>
+            );
+          })}
         <Link
           className="mx-auto mt-4 block w-[186px] rounded-xl border-[1px] border-slate-50 py-3.5 text-center text-lg font-medium transition-all hover:scale-95 hover:opacity-70"
           href="/addteam"

--- a/app/components/Gnb/TeamListDropDown.tsx
+++ b/app/components/Gnb/TeamListDropDown.tsx
@@ -35,14 +35,14 @@ export default function TeamListDropDown({
           .sort((a, b) => b.id - a.id) // id순 내림차순 정렬
           .map((team) => {
             return (
-              <Link
-                href={`/${team.id}`}
+              <Dropdown.MenuItem
+                className="pb-[8px] pt-[8px]"
                 key={team.id}
               >
-                <Dropdown.MenuItem className="pb-[8px] pt-2">
+                <Link href={`/${team.id}`}>
                   <TeamListDropDownItem team={team} />
-                </Dropdown.MenuItem>
-              </Link>
+                </Link>
+              </Dropdown.MenuItem>
             );
           })}
         <Link

--- a/app/components/Gnb/TeamListDropDownItem.tsx
+++ b/app/components/Gnb/TeamListDropDownItem.tsx
@@ -10,7 +10,7 @@ export default function TeamListDropDownItem({
 }: TeamListDropDownItemProps) {
   return (
     <div className="flex items-center gap-3">
-      <div className="relative size-8 overflow-hidden rounded-md">
+      <div className="relative h-8 w-8 flex-shrink-0 overflow-hidden rounded-md">
         <Image
           src={team.image || '/images/icons/ic_team.svg'}
           alt="팀 이미지"

--- a/app/components/Gnb/index.tsx
+++ b/app/components/Gnb/index.tsx
@@ -23,11 +23,11 @@ export default function GNB() {
   const isLoginMenuHidden = currentPath == '/login' || currentPath == '/signup';
 
   const { user } = useUserStore();
-  const { setTeamList, currentTeam, setCurrentTeam } = useTeamStore();
+  const { teamList, setTeamList, currentTeam, setCurrentTeam } = useTeamStore();
 
   const [isSideBarOpen, setIsSideBarOpen] = useState(false);
 
-  const { data: teamList = [] } = useQuery({
+  const { data: fetchedteamList = [] } = useQuery({
     queryKey: ['coworkers-teamList', user?.id],
     queryFn: getUserGroups,
     staleTime: 1000 * 60 * 5,
@@ -36,15 +36,15 @@ export default function GNB() {
   });
 
   useEffect(() => {
-    if (teamList.length > 0) {
+    if (fetchedteamList.length > 0) {
       const currentTeamList = useTeamStore.getState();
 
-      if (!isEqual(teamList, currentTeamList)) {
-        setTeamList(teamList);
+      if (!isEqual(fetchedteamList, currentTeamList.teamList)) {
+        setTeamList(fetchedteamList);
       }
 
-      if (!teamId) {
-        setCurrentTeam(currentTeam?.id || teamList[0]?.id);
+      if (!teamId || teamId === currentTeam?.id) {
+        setCurrentTeam(currentTeam?.id || fetchedteamList[0]?.id);
         return;
       }
 
@@ -52,7 +52,7 @@ export default function GNB() {
         setCurrentTeam(teamId);
       }
     }
-  }, [teamList, setTeamList, teamId, setCurrentTeam, currentTeam]);
+  }, [fetchedteamList, setTeamList, teamId, setCurrentTeam, currentTeam]);
 
   const handleOpenSideBar = () => {
     setIsSideBarOpen(true);


### PR DESCRIPTION
## 📌 Related Issue

## 🧾 작업 사항
- gnb 팀 리스트 드롭다운, 프로필 드롭다운에서 팀 선택 시 드롭다운이 닫히도록 수정
- 팀 생성/수정/삭제 시 gnb 팀 리스트 동기화
- 드롭다운의 팀 이름이 길어질 때 이미지가 깨지는 현상 해결
- 태블릿 버전 드롭다운(모바일은 없음, 데스크탑은 길이 제한)에서 팀 이름에 `truncate` 추가. 약 12자까지 정상 출력

## 📚 리뷰 포인트
- gnb 기능 상의 문제를 몇 가지 개선했습니다.
- 팀 리스트를 동기화 하는 부분은 각각의 페이지에서 `queryClient`를 사용해 캐시를 무효화하거나 분명히 재 요청하는 방식으로 처리했습니다. 

## 📷 Screenshot/GIF
![image](https://github.com/user-attachments/assets/2c8a3f6c-30f7-4ca9-8dcb-1c4e8829c7df)
