### PR TITLE
fix: 카카오 로그인 환경변수 누락 수정

### DIFF
--- a/app/oauth/kakao/page.tsx
+++ b/app/oauth/kakao/page.tsx
@@ -38,7 +38,7 @@ const KakaoCallback = () => {
 
       kakaoLoginMutation.mutate({
         state: receivedState,
-        redirectUri: 'http://localhost:3000/oauth/kakao',
+        redirectUri: process.env.NEXT_PUBLIC_KAKAO_LOGIN_REDIRECT_URI,
         token: code,
         provider: 'KAKAO',
       });


### PR DESCRIPTION
## 🧾 작업 사항
- 카카오 로그인 요청 시의 `redirectUri`에 환경 변수가 아닌 문자열이 할당되어 있던 부분을 수정하여 환경 변수를 적용
