### PR TITLE
Refactor/#106 팀 페이지 리펙토링

### DIFF
--- a/app/[teamid]/GroupInfo.tsx
+++ b/app/[teamid]/GroupInfo.tsx
@@ -1,0 +1,119 @@
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
+
+import type { GroupType } from '../types/shared';
+import useUserStore from '../stores/userStore';
+import useTeamStore from '../stores/teamStore';
+import { deleteGroups } from '../api/group.api';
+
+import Dropdown from '../components/Dropdown';
+import Modal, { ModalFooter } from '../components/Modal';
+import Button from '../components/Button';
+
+import GearIcon from '../components/icons/GearIcon';
+import styles from './teampage.module.css';
+
+export default function GroupInfo({ id, name, image }: GroupType) {
+  const [modal, setModal] = useState(false);
+
+  const router = useRouter();
+  const { user } = useUserStore();
+  const { teamList, setCurrentTeam, clearTeam } = useTeamStore();
+  const queryClient = useQueryClient();
+
+  const bgImage = image ? { backgroundImage: `url(${image})` } : {};
+
+  // 팀 수정하기 버튼 클릭 함수
+  const handleModifyClick = () => {
+    router.push(`/${id}/modify`);
+  };
+
+  // 팀 삭제하기 버튼 클릭
+  const handleDeleteClick = () => {
+    setModal(true);
+  };
+
+  // 팀 진짜로 삭제하기 버튼 클릭
+  const handleRealDeleteClick = async () => {
+    const result = await deleteGroups({ groupId: id });
+
+    if (teamList.length)
+      await queryClient.refetchQueries({
+        queryKey: ['coworkers-teamList', user?.id],
+      });
+
+    // 최신화된 팀 데이터 확인
+    const updatedTeamList =
+      queryClient.getQueryData<GroupType[]>(['coworkers-teamList', user?.id]) ||
+      [];
+
+    if (updatedTeamList.length > 0) {
+      // 팀이 남아있다면 첫 번째 팀을 현재 팀으로 설정
+      setCurrentTeam(updatedTeamList[0].id);
+    } else {
+      // 팀이 없다면 currentTeam을 null로 초기화
+      clearTeam();
+    }
+
+    console.log('--- deleteGroups:result:', result);
+    router.replace('/');
+  };
+
+  // 모달 닫기
+  const handleModalClose = () => {
+    setModal(false);
+  };
+
+  return (
+    <header
+      className={styles.header}
+      style={bgImage}
+    >
+      <h1 className={styles.headerTitle}>
+        {name}({id})
+      </h1>
+
+      <Dropdown className="z-10 h-6">
+        <Dropdown.Button>
+          <GearIcon />
+        </Dropdown.Button>
+        <Dropdown.Menu className="right-0">
+          <Dropdown.MenuItem onClick={handleModifyClick}>
+            수정하기
+          </Dropdown.MenuItem>
+          <Dropdown.MenuItem onClick={handleDeleteClick}>
+            삭제하기
+          </Dropdown.MenuItem>
+        </Dropdown.Menu>
+      </Dropdown>
+
+      <Modal
+        isOpen={modal}
+        title="팀을 정말로 삭제하실 건가요?"
+        onClose={handleModalClose}
+        icon="danger"
+      >
+        <p className="text-pretty break-keep text-center">
+          모든 할 일 목록 및 할 일은 삭제처리 됩니다.
+        </p>
+
+        <ModalFooter>
+          <Button
+            styleType="outlined-secondary"
+            onClick={handleModalClose}
+          >
+            취소
+          </Button>
+
+          <Button
+            state="danger"
+            onClick={handleRealDeleteClick}
+          >
+            팀 삭제
+          </Button>
+        </ModalFooter>
+      </Modal>
+    </header>
+  );
+}

--- a/app/[teamid]/MemberList.tsx
+++ b/app/[teamid]/MemberList.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import Image from 'next/image';
 import { useQuery } from '@tanstack/react-query';
 
 import { cn } from '../libs/utils';
@@ -10,6 +9,7 @@ import MemberListItem from './MemberListItem';
 import Button from '../components/Button';
 
 import styles from './teampage.module.css';
+import Img from '../components/Img';
 
 export type MemberProps = {
   userId: number;
@@ -109,11 +109,9 @@ export default function MemberList({ groupId, members, role }: Props) {
       >
         <div className="flex flex-col items-center gap-6">
           <figure className={cn(styles.memberFigure, 'size-14')}>
-            <Image
-              src={
-                members[memberIdx].userImage ||
-                '/images/icons/icon-base-user.svg'
-              }
+            <Img
+              src={members[memberIdx].userImage}
+              baseImage="/images/icons/icon-base-user.svg"
               width="40"
               height="40"
               alt=""

--- a/app/[teamid]/MemberListItem.tsx
+++ b/app/[teamid]/MemberListItem.tsx
@@ -1,7 +1,7 @@
-import Image from 'next/image';
 import { cn } from '../libs/utils';
 
 import type { MemberProps } from './MemberList';
+import Img from '../components/Img';
 
 // import KebabIcon from '../components/icons/KebabIcon';
 import styles from './teampage.module.css';
@@ -30,8 +30,9 @@ export default function MemberListItem({
         onClick={handleClick}
       >
         <figure className={cn(styles.memberFigure, 'size-8')}>
-          <Image
-            src={userImage || '/images/icons/icon-base-user.svg'}
+          <Img
+            src={userImage}
+            baseImage="/images/icons/icon-base-user.svg"
             width="26"
             height="26"
             alt=""

--- a/app/[teamid]/TaskListsItem.tsx
+++ b/app/[teamid]/TaskListsItem.tsx
@@ -59,7 +59,7 @@ export default function TaskListsItem({
 
       <Dropdown>
         <Dropdown.Button className={styles.iconButton}>
-          <KebabIcon classname="size-3 mx-auto" />
+          <KebabIcon classname="size-4 mx-auto" />
         </Dropdown.Button>
         <Dropdown.Menu className="right-0">
           <Dropdown.MenuItem onClick={handleEditClick}>수정</Dropdown.MenuItem>

--- a/app/[teamid]/layout.tsx
+++ b/app/[teamid]/layout.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from 'react';
+import { Metadata } from 'next';
+
+interface Props {
+  children: ReactNode;
+}
+
+export const metadata: Metadata = {
+  title: '팀 페이지',
+  description: '팀 페이지 입니다. 할 일 목록 및 맴버를 관리하세요.',
+};
+
+export default function Layout({ children }: Props) {
+  return <>{children}</>;
+}

--- a/app/[teamid]/page.tsx
+++ b/app/[teamid]/page.tsx
@@ -2,24 +2,19 @@
 
 import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 
-import { GroupType } from '../types/shared';
-import { getGroups, deleteGroups } from '../api/group.api';
-import useUserStore from '../stores/userStore';
 import { GroupResponseType } from '../types/group';
+import { getGroups } from '../api/group.api';
+import useUserStore from '../stores/userStore';
 
 import TaskLists from './TaskLists';
 import MemberList from './MemberList';
 import Report from './Report';
-import Dropdown from '../components/Dropdown';
 import Modal, { ModalFooter } from '../components/Modal';
 import Button from '../components/Button';
 import Loading from '../components/Loading';
-
-import GearIcon from '../components/icons/GearIcon';
-import styles from './teampage.module.css';
-import useTeamStore from '../stores/teamStore';
+import GroupInfo from './GroupInfo';
 
 export default function TeamPage() {
   const { teamid } = useParams();
@@ -27,14 +22,10 @@ export default function TeamPage() {
   const [role, setRole] = useState('');
   const [totalTasks, setTotalTasks] = useState(0);
   const [completedTasks, setCompletedTasks] = useState(0);
-  const [deleteModal, setDeleteModal] = useState(false);
   const [incorrectModal, setIncorrectModal] = useState(false);
 
   const { user } = useUserStore();
-  const { teamList, setCurrentTeam, clearTeam } = useTeamStore();
-
   const router = useRouter();
-  const queryClient = useQueryClient();
 
   const {
     data: group,
@@ -69,52 +60,7 @@ export default function TeamPage() {
       setTotalTasks(total);
       setCompletedTasks(complete);
     }
-  }, [group, user, router]);
-
-  // 그룹 이미지를 배경 이미지로
-  const bgImage = group?.image
-    ? { backgroundImage: `url(${group.image})` }
-    : {};
-
-  // 팀 수정하기 버튼 클릭 함수
-  const handleModifyClick = () => {
-    router.push(`/${group?.id}/modify`);
-  };
-
-  // 팀 삭제하기 버튼 클릭
-  const handleDeleteClick = () => {
-    setDeleteModal(true);
-  };
-
-  // 팀 진짜로 삭제하기 버튼 클릭
-  const handleRealDeleteClick = async () => {
-    if (group) {
-      const result = await deleteGroups({ groupId: group.id });
-
-      if (teamList.length)
-        await queryClient.refetchQueries({
-          queryKey: ['coworkers-teamList', user?.id],
-        });
-
-      // 최신화된 팀 데이터 확인
-      const updatedTeamList =
-        queryClient.getQueryData<GroupType[]>([
-          'coworkers-teamList',
-          user?.id,
-        ]) || [];
-
-      if (updatedTeamList.length > 0) {
-        // 팀이 남아있다면 첫 번째 팀을 현재 팀으로 설정
-        setCurrentTeam(updatedTeamList[0].id);
-      } else {
-        // 팀이 없다면 currentTeam을 null로 초기화
-        clearTeam();
-      }
-
-      console.log('--- deleteGroups:result:', result);
-      router.replace('/');
-    }
-  };
+  }, [group, user]);
 
   // 팀 검증 실패 모달에서 메인페이지로 이동시킴
   const handleIncorrectModalClose = () => {
@@ -163,28 +109,7 @@ export default function TeamPage() {
 
   return (
     <div className="container flex flex-col py-6">
-      <header
-        className={styles.header}
-        style={bgImage}
-      >
-        <h1 className={styles.headerTitle}>
-          {group.name}({group.id})
-        </h1>
-
-        <Dropdown className="h-6">
-          <Dropdown.Button>
-            <GearIcon />
-          </Dropdown.Button>
-          <Dropdown.Menu className="right-0">
-            <Dropdown.MenuItem onClick={handleModifyClick}>
-              수정하기
-            </Dropdown.MenuItem>
-            <Dropdown.MenuItem onClick={handleDeleteClick}>
-              삭제하기
-            </Dropdown.MenuItem>
-          </Dropdown.Menu>
-        </Dropdown>
-      </header>
+      <GroupInfo {...group} />
 
       <TaskLists
         groupId={group.id}
@@ -203,33 +128,6 @@ export default function TeamPage() {
         members={group.members}
         role={role}
       />
-
-      <Modal
-        isOpen={deleteModal}
-        title="팀을 정말로 삭제하실 건가요?"
-        onClose={() => setDeleteModal(false)}
-        icon="danger"
-      >
-        <p className="text-pretty break-keep text-center">
-          모든 할 일 목록 및 할 일은 삭제처리 됩니다.
-        </p>
-
-        <ModalFooter>
-          <Button
-            styleType="outlined-secondary"
-            onClick={() => setDeleteModal(false)}
-          >
-            취소
-          </Button>
-
-          <Button
-            state="danger"
-            onClick={handleRealDeleteClick}
-          >
-            팀 삭제
-          </Button>
-        </ModalFooter>
-      </Modal>
     </div>
   );
 }

--- a/app/[teamid]/teampage.module.css
+++ b/app/[teamid]/teampage.module.css
@@ -5,11 +5,17 @@
 }
 
 .header {
-  @apply flex items-center justify-between rounded-xl border border-bd-primary bg-slate-50/10 bg-[url('/images/bg-team-header.svg')] bg-clip-padding bg-[center_right_80px] bg-no-repeat px-6 py-5;
-  background-size: 180px auto;
+  @apply relative flex items-center justify-between rounded-xl border border-bd-primary bg-slate-50/10 bg-[url('/images/bg-team-header.svg')] bg-cover bg-clip-padding bg-center bg-no-repeat px-6 py-5 sm:bg-[180px_auto] sm:bg-[center_right_80px];
+  /* background-size: 180px auto; */
 
   .headerTitle {
-    @apply text-xl font-bold text-t-inverse;
+    @apply z-10 truncate text-xl font-bold text-t-inverse sm:bg-transparent;
+
+    &::before {
+      @apply absolute inset-0 -z-[1] rounded-xl backdrop-brightness-75;
+      content: '';
+      background-image: linear-gradient(135deg, var(--b-secondary) 30%, #fff0);
+    }
   }
 }
 .progress {

--- a/app/addteam/page.tsx
+++ b/app/addteam/page.tsx
@@ -6,13 +6,14 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { postGroups } from '../api/group.api';
 import useTeamStore from '../stores/teamStore';
+import useUserStore from '../stores/userStore';
+import { MAX_LENGTH } from '../constants/form';
 
 import InputField from '../components/InputField';
 import ImageUpload from '../components/ImageUpload';
 import Button from '../components/Button';
 
 import styles from '../styles/team.module.css';
-import useUserStore from '../stores/userStore';
 
 const MIN_NAME_LENGTH = 2;
 
@@ -115,7 +116,11 @@ export default function AddTeamPage() {
           placeholder="팀 이름을 입력해주세요."
           onChange={(e) => setName(e.target.value)}
           errorMessage={nameErrorMessage}
+          maxlength={MAX_LENGTH.teamName}
         />
+        <div className="help-message">
+          팀 이름은 최대 {MAX_LENGTH.taskListName}자 입니다.
+        </div>
 
         <Button
           type="submit"

--- a/app/components/Img.tsx
+++ b/app/components/Img.tsx
@@ -1,0 +1,31 @@
+import Image, { ImageProps } from 'next/image';
+import BaseImage from '@/public/images/icons/ic_image.svg';
+
+interface Props extends ImageProps {
+  baseImage?: string;
+}
+
+export default function Img({
+  baseImage = '',
+  src,
+  alt = '',
+  ...props
+}: Props) {
+  // Error Handler
+  const handleError = (e: React.SyntheticEvent<HTMLImageElement>) => {
+    const target = e.currentTarget;
+    target.srcset = '';
+    target.src = baseImage || BaseImage.src;
+  };
+
+  return (
+    <Image
+      src={src || baseImage || BaseImage}
+      alt={alt}
+      onError={handleError}
+      placeholder="blur"
+      blurDataURL="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVR42mN8//HLfwYiAOOoQvoqBABbWyZJf74GZgAAAABJRU5ErkJggg=="
+      {...props}
+    />
+  );
+}

--- a/app/constants/form.ts
+++ b/app/constants/form.ts
@@ -2,5 +2,5 @@ export const MAX_LENGTH = {
   teamName: 30,
   nickName: 50,
   taskName: 100,
-  taskListName: 50,
+  taskListName: 30,
 };

--- a/app/dummy/layout.tsx
+++ b/app/dummy/layout.tsx
@@ -1,45 +1,36 @@
-import Link from 'next/link';
 import { ReactNode } from 'react';
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
 
 interface Props {
   children: ReactNode;
 }
 
-const LINKS = [
-  {
-    href: '/dummy/modal',
-    text: 'modal',
-  },
-  {
-    href: '/dummy/dropdown',
-    text: 'dropdown',
-  },
-  {
-    href: '/dummy/loading',
-    text: 'loading',
-  },
-  {
-    href: '/dummy/button',
-    text: 'button',
-  },
-  {
-    href: '/dummy/textfield',
-    text: 'textfield',
-  },
-];
+export const metadata: Metadata = {
+  title: '테스트 페이지',
+};
+
+// aside nav
+const PAGES = ['modal', 'dropdown', 'loading', 'button', 'textfield'];
 
 export default function Layout({ children }: Props) {
+  // 개발 환경에서만 접근 가능하도록 수정
+  if (process.env.NODE_ENV !== 'development') {
+    return notFound();
+  }
+
   return (
     <div className="container flex flex-col gap-4 py-6 sm:flex-row">
       <aside className="w-full flex-none self-start rounded-xl bg-b-secondary p-4 sm:w-1/4">
         <ul className="flex gap-1 sm:flex-col">
-          {LINKS.map(({ href, text }) => (
-            <li key={text}>
+          {PAGES.map((name) => (
+            <li key={name}>
               <Link
-                href={href}
+                href={`/dummy/${name}`}
                 className="text-button block rounded-md px-2 py-1 hover:bg-b-tertiary"
               >
-                {text}
+                {name}
               </Link>
             </li>
           ))}

--- a/app/dummy/page.tsx
+++ b/app/dummy/page.tsx
@@ -1,11 +1,4 @@
-import { notFound } from 'next/navigation';
-
 export default function DummyPage() {
-  // 개발 환경에서만 접근 가능하도록 수정
-  if (process.env.NODE_ENV !== 'development') {
-    return notFound();
-  }
-
   return (
     <>
       <h1 className="my-2 text-xl font-bold">Dummy Pages</h1>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -12,7 +12,7 @@ export default function NotFound() {
           href="/"
           className="text-primary underline"
         >
-          홈 페이지로 가기 &rarr;
+          메인 페이지로 가기 &rarr;
         </Link>
       </div>
     </div>


### PR DESCRIPTION
## 📌 Related Issue
- Closed #106 

## 🧾 작업 사항
- 이미지 컴포넌트 추가
- 사용자 이미지 깨지는 부분 처리
- 할 일 목록 및 팀 이름 글자 수 확인 및 제한 적용
- 코드 분리
- 기타 텍스트 수정 및 코드 정리
- 타이틀 적용

## 📚 리뷰 포인트
- 팀 이미지 보이는 부분 모바일 반응형을 추가했습니다.
- 사용자 이미지 깨지는 부분을 이미지 컴포넌트로 처리하였습니다.
- 팀 페이지 코드를 분리하였습니다.
- 글자수 제한을 확인하여 적용하였습니다.

## 📷 Screenshot/GIF
![image](https://github.com/user-attachments/assets/0667d71a-d416-41db-9b78-b576cdee6604)
![image](https://github.com/user-attachments/assets/18473374-3b1a-4277-89da-4ba3fb704f9e)
