### PR TITLE
Refactor/#117  이미지 로딩속도 개선

### DIFF
--- a/app/noteam/page.tsx
+++ b/app/noteam/page.tsx
@@ -1,10 +1,21 @@
+import Image from 'next/image';
 import Button from '../components/Button';
 
 export default function NoTeamPage() {
   return (
     <div className="mt-[190px] px-8 sm:px-[112px] lg:mx-auto">
       <div className="flex flex-col items-center gap-8 sm:gap-12">
-        <div className="aspect-[810/255] w-full max-w-[810px] bg-[url('/images/bg-no-team.png')] bg-contain" />
+        <div className="w-full max-w-[810px]">
+          <Image
+            src="/images/bg-no-team.png"
+            alt=""
+            layout="responsive"
+            priority
+            width={810}
+            height={255}
+            className="object-contain"
+          />
+        </div>
         <p className="text-center text-md text-t-default lg:text-lg">
           아직 소속된 팀이 없습니다.
           <br />

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,7 @@ const nextConfig: NextConfig = {
       'sprint-fe-project.s3.ap-northeast-2.amazonaws.com',
       'picsum.photos',
     ],
+    formats: ['image/avif', 'image/webp'],
   },
 };
 


### PR DESCRIPTION
## 📌 Related Issue
- Closed #117

## 🧾 작업 사항
- 이미지 로딩속도 개선
- noteam 페이지 이미지 next/Image로 전환

## 📚 리뷰 포인트
- 이것저것 만져보다가 적용해봤는데 배포 환경에서도 잘 적용될지 모르겠습니다. 우선 올려보겠습니다.
- AVIF 형식이 사용 가능한 브라우저에서는 해당 형식으로 로드하도록 변경했습니다 (지원하지 않을 경우 WebP 사용) [참고](https://nextjs.org/blog/next-12#smaller-images-using-avif)
- 가장 위에 받아오는 이미지가 랜딩 첫 이미지이고, 캐시 삭제 후 접속했을때 3초정도 걸리던 것이 15ms로 줄었습니다만, 올려보고 제대로 적용되는지 다시 확인해보겠습니다
![스크린샷 2025-02-10 오후 5 18 15](https://github.com/user-attachments/assets/99383aec-8886-44d3-b127-c99272356716)
- 추가로, 테스트 해 보았을 때 sharp 라이브러리를 썼을때 이미지 로딩 시간이 조금 더 빠릅니다. next.js에서는 기본적으로 이미지 최적화 모듈인 squoosh를 사용하고 있지만, next start를 사용한 프로덕션 환경에서는 sharp를 설치하는 것이 권장됩니다. 하지만 저희 배포 환경인 netlify에서는 sharp module을 사용했을 때 에러가 난다는 글을 몇몇 봐서 설치하지는 않았습니다.. 로컬이나 vercel 에서는 잘 동작한다고 하네요. 우선은 이렇게 두는게 좋을 것 같습니다만 참고하시라고 몇마디 덧붙여봅니다 .. [참고](https://oliveyoung.tech/2023-06-09/nextjs-image-optimization/)

