### PR TITLE
Feat/121  자유게시판 개선작업 2차

### DIFF
--- a/app/boards/BestCardList.tsx
+++ b/app/boards/BestCardList.tsx
@@ -6,7 +6,6 @@ import HeartIcon from '@/public/images/icons/ic-heart.svg';
 import MedalIcon from '@/public/images/icons/ic_medal.svg';
 import dayjs from 'dayjs';
 import Link from 'next/link';
-import Loading from '../components/Loading';
 
 export default function BestCardList() {
   const articles = Card({
@@ -16,7 +15,7 @@ export default function BestCardList() {
     keyword: '',
   });
   return (
-    <div className="flex justify-between gap-[20px]">
+    <div className="flex w-full justify-between gap-[20px]">
       {articles && articles.list.length > 0 ? (
         articles.list.map((article) => (
           <Link
@@ -71,8 +70,37 @@ export default function BestCardList() {
           </Link>
         ))
       ) : (
-        <div className="col-span-2 flex w-full items-center justify-center">
-          <Loading text="" />
+        <div className="flex w-full gap-5 overflow-hidden">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div
+              key={index}
+              className={`flex h-[220px] w-full animate-pulse rounded-[12px] border border-gray-700 bg-b-secondary px-[32px] py-[29px] ${
+                index >= 2
+                  ? 'md:inline-flex hidden lg:inline-flex'
+                  : index === 1
+                    ? 'md:w-1/2 hidden sm:inline-flex'
+                    : 'w-full'
+              }`}
+            >
+              <div className="mb-2 flex flex-1 flex-col justify-between">
+                <div className="mb-2 h-[13px] w-1/4 rounded-md bg-gray-500"></div>
+
+                <div className="flex items-center gap-4">
+                  <div className="flex flex-1 flex-col">
+                    <div className="mb-2 h-[17px] w-3/4 rounded-md bg-gray-500"></div>
+                    <div className="mb-4 h-[17px] w-1/2 rounded-md bg-gray-500"></div>
+                  </div>
+                  <div className="flex-shrink-0">
+                    <div className="h-[72px] w-[72px] rounded-md bg-gray-500"></div>
+                  </div>
+                </div>
+
+                <div className="mt-auto flex w-full justify-between">
+                  <div className="h-[14px] w-[80px] rounded-md bg-gray-500"></div>
+                </div>
+              </div>
+            </div>
+          ))}
         </div>
       )}
     </div>

--- a/app/boards/BestCardList.tsx
+++ b/app/boards/BestCardList.tsx
@@ -6,6 +6,7 @@ import HeartIcon from '@/public/images/icons/ic-heart.svg';
 import MedalIcon from '@/public/images/icons/ic_medal.svg';
 import dayjs from 'dayjs';
 import Link from 'next/link';
+import Loading from '../components/Loading';
 
 export default function BestCardList() {
   const articles = Card({
@@ -70,7 +71,9 @@ export default function BestCardList() {
           </Link>
         ))
       ) : (
-        <p>로딩중...</p>
+        <div className="col-span-2 flex w-full items-center justify-center">
+          <Loading text="" />
+        </div>
       )}
     </div>
   );

--- a/app/boards/BestCardList.tsx
+++ b/app/boards/BestCardList.tsx
@@ -6,6 +6,7 @@ import HeartIcon from '@/public/images/icons/ic-heart.svg';
 import MedalIcon from '@/public/images/icons/ic_medal.svg';
 import dayjs from 'dayjs';
 import Link from 'next/link';
+import SkeletonCard from './SkeletonCard';
 
 export default function BestCardList() {
   const articles = Card({
@@ -72,34 +73,17 @@ export default function BestCardList() {
       ) : (
         <div className="flex w-full gap-5 overflow-hidden">
           {Array.from({ length: 3 }).map((_, index) => (
-            <div
+            <SkeletonCard
               key={index}
-              className={`flex h-[220px] w-full animate-pulse rounded-[12px] border border-gray-700 bg-b-secondary px-[32px] py-[29px] ${
+              variant="best"
+              className={`h-[220px] w-full ${
                 index >= 2
                   ? 'md:inline-flex hidden lg:inline-flex'
                   : index === 1
                     ? 'md:w-1/2 hidden sm:inline-flex'
                     : 'w-full'
               }`}
-            >
-              <div className="mb-2 flex flex-1 flex-col justify-between">
-                <div className="mb-2 h-[13px] w-1/4 rounded-md bg-gray-500"></div>
-
-                <div className="flex items-center gap-4">
-                  <div className="flex flex-1 flex-col">
-                    <div className="mb-2 h-[17px] w-3/4 rounded-md bg-gray-500"></div>
-                    <div className="mb-4 h-[17px] w-1/2 rounded-md bg-gray-500"></div>
-                  </div>
-                  <div className="flex-shrink-0">
-                    <div className="h-[72px] w-[72px] rounded-md bg-gray-500"></div>
-                  </div>
-                </div>
-
-                <div className="mt-auto flex w-full justify-between">
-                  <div className="h-[14px] w-[80px] rounded-md bg-gray-500"></div>
-                </div>
-              </div>
-            </div>
+            />
           ))}
         </div>
       )}

--- a/app/boards/CardList.tsx
+++ b/app/boards/CardList.tsx
@@ -5,12 +5,13 @@ import Image from 'next/image';
 import HeartIcon from '@/public/images/icons/ic-heart.svg';
 import dayjs from 'dayjs';
 import { ArticleResponseType } from '@/app/types/article';
-import { useState } from 'react';
 import Pagination from './Pagination';
 import Dropdown from '@/app/components/Dropdown';
 import PostActionDropdown from './PostActionDropdown';
 import useUserStore from '@/app/stores/userStore';
 import Link from 'next/link';
+import { useSearchParams, useRouter, usePathname } from 'next/navigation';
+import { useState } from 'react';
 
 export default function CardList({
   keyword,
@@ -22,7 +23,11 @@ export default function CardList({
   hideItem?: boolean;
 }) {
   const { user } = useUserStore();
-  const [currentPage, setCurrentPage] = useState(1);
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const currentPage = Number(searchParams.get('page')) || 1;
   const [totalPages, setTotalPages] = useState(1);
   const [orderByDropdown, setOrderByDropdown] = useState<'recent' | 'like'>(
     orderBy
@@ -41,15 +46,14 @@ export default function CardList({
     }
   }
 
-  const handlePageChange = (page: number) => {
-    if (page >= 1 && page <= totalPages) {
-      setCurrentPage(page);
-    }
-  };
-
   const handleOrderChange = (newOrder: 'recent' | 'like') => {
     setOrderByDropdown(newOrder);
-    setCurrentPage(1);
+
+    const params = new URLSearchParams(searchParams);
+    params.set('page', '1');
+    params.set('orderBy', newOrder);
+
+    router.push(`${pathname}?${params.toString()}`, { scroll: false });
   };
 
   return (
@@ -94,7 +98,7 @@ export default function CardList({
               return (
                 <Link
                   key={article.id}
-                  href={`/boards/${article.id}`}
+                  href={`/boards/${article.id}?page=${currentPage}`}
                   className="pointer-events-auto block"
                 >
                   <div
@@ -176,7 +180,6 @@ export default function CardList({
         <Pagination
           currentPage={currentPage}
           totalPages={totalPages}
-          onPageChange={handlePageChange}
         />
       )}
     </div>

--- a/app/boards/CardList.tsx
+++ b/app/boards/CardList.tsx
@@ -174,7 +174,7 @@ export default function CardList({
           [...Array(pageSize)].map((_, index) => (
             <div
               key={index}
-              className="flex h-[175px] animate-pulse flex-row rounded-[12px] border border-gray-700 bg-b-secondary px-[32px] py-[24px]"
+              className="flex h-[175px] w-full animate-pulse flex-row rounded-[12px] border border-gray-700 bg-b-secondary px-[32px] py-[24px]"
             >
               <div className="flex flex-1 flex-col justify-between">
                 <div>

--- a/app/boards/CardList.tsx
+++ b/app/boards/CardList.tsx
@@ -171,7 +171,27 @@ export default function CardList({
             </div>
           )
         ) : (
-          <p>로딩중...</p>
+          [...Array(pageSize)].map((_, index) => (
+            <div
+              key={index}
+              className="flex h-[175px] animate-pulse flex-row rounded-[12px] border border-gray-700 bg-b-secondary px-[32px] py-[24px]"
+            >
+              <div className="flex flex-1 flex-col justify-between">
+                <div>
+                  <div className="mb-2 h-[17px] w-3/4 rounded-md bg-gray-500"></div>
+                  <div className="mb-4 h-[17px] w-1/2 rounded-md bg-gray-500"></div>
+                </div>
+
+                <div className="mt-auto flex w-full justify-between">
+                  <div className="h-[14px] w-[80px] rounded-md bg-gray-500"></div>
+                </div>
+              </div>
+
+              <div className="ml-4 flex-shrink-0">
+                <div className="h-[72px] w-[72px] rounded-md bg-gray-500"></div>
+              </div>
+            </div>
+          ))
         )}
       </div>
 

--- a/app/boards/CardList.tsx
+++ b/app/boards/CardList.tsx
@@ -12,6 +12,7 @@ import useUserStore from '@/app/stores/userStore';
 import Link from 'next/link';
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 import { useState } from 'react';
+import SkeletonCard from './SkeletonCard';
 
 export default function CardList({
   keyword,
@@ -172,25 +173,11 @@ export default function CardList({
           )
         ) : (
           [...Array(pageSize)].map((_, index) => (
-            <div
+            <SkeletonCard
               key={index}
-              className="flex h-[175px] w-full animate-pulse flex-row rounded-[12px] border border-gray-700 bg-b-secondary px-[32px] py-[24px]"
-            >
-              <div className="flex flex-1 flex-col justify-between">
-                <div>
-                  <div className="mb-2 h-[17px] w-3/4 rounded-md bg-gray-500"></div>
-                  <div className="mb-4 h-[17px] w-1/2 rounded-md bg-gray-500"></div>
-                </div>
-
-                <div className="mt-auto flex w-full justify-between">
-                  <div className="h-[14px] w-[80px] rounded-md bg-gray-500"></div>
-                </div>
-              </div>
-
-              <div className="ml-4 flex-shrink-0">
-                <div className="h-[72px] w-[72px] rounded-md bg-gray-500"></div>
-              </div>
-            </div>
+              variant="list"
+              className="h-[175px] w-full flex-row"
+            />
           ))
         )}
       </div>

--- a/app/boards/Pagination.tsx
+++ b/app/boards/Pagination.tsx
@@ -1,14 +1,27 @@
 'use client';
 
+import { useRouter, usePathname, useSearchParams } from 'next/navigation';
+
 export default function Pagination({
   currentPage,
   totalPages,
-  onPageChange,
 }: {
   currentPage: number;
   totalPages: number;
-  onPageChange: (page: number) => void;
 }) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const onPageChange = (page: number) => {
+    if (page < 1 || page > totalPages) return;
+
+    const params = new URLSearchParams(searchParams);
+    params.set('page', page.toString());
+
+    router.push(`${pathname}?${params.toString()}`, { scroll: false });
+  };
+
   return (
     <div className="mt-6 flex justify-center space-x-2 py-8">
       <button

--- a/app/boards/SkeletonCard.tsx
+++ b/app/boards/SkeletonCard.tsx
@@ -11,7 +11,7 @@ export default function SkeletonCard({
     >
       <div className="flex flex-1 flex-col justify-between">
         {variant === 'best' && (
-          <div className="mb-2 h-[13px] w-1/4 rounded-md bg-gray-500" />
+          <div className="mb-[15px] mt-2 h-[13px] w-1/4 rounded-md bg-gray-500" />
         )}
 
         <div className="flex items-center gap-4">

--- a/app/boards/SkeletonCard.tsx
+++ b/app/boards/SkeletonCard.tsx
@@ -1,0 +1,33 @@
+export default function SkeletonCard({
+  className,
+  variant = 'best',
+}: {
+  className?: string;
+  variant?: 'best' | 'list';
+}) {
+  return (
+    <div
+      className={`flex animate-pulse rounded-[12px] border border-gray-700 bg-b-secondary px-[32px] py-[24px] ${className}`}
+    >
+      <div className="flex flex-1 flex-col justify-between">
+        {variant === 'best' && (
+          <div className="mb-2 h-[13px] w-1/4 rounded-md bg-gray-500" />
+        )}
+
+        <div className="flex items-center gap-4">
+          <div className="flex flex-1 flex-col">
+            <div className="mb-2 h-[17px] w-3/4 rounded-md bg-gray-500" />
+            <div className="mb-4 h-[17px] w-1/2 rounded-md bg-gray-500" />
+          </div>
+          <div className="flex-shrink-0">
+            <div className="h-[72px] w-[72px] rounded-md bg-gray-500" />
+          </div>
+        </div>
+
+        <div className="mt-auto flex w-full justify-between">
+          <div className="h-[14px] w-[80px] rounded-md bg-gray-500" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/boards/[articleId]/Comments.tsx
+++ b/app/boards/[articleId]/Comments.tsx
@@ -36,7 +36,6 @@ export default function Comment() {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-    isLoading: isQueryLoading,
   } = useInfiniteQuery({
     queryKey: ['articleComments', Number(articleId)],
     queryFn: async ({ pageParam }: { pageParam?: number }) => {
@@ -104,7 +103,6 @@ export default function Comment() {
     },
   });
 
-  if (isQueryLoading) return <p>로딩 중...</p>;
   if (!comments) return;
 
   return (

--- a/app/boards/[articleId]/Comments.tsx
+++ b/app/boards/[articleId]/Comments.tsx
@@ -176,26 +176,18 @@ export default function Comment() {
                 )}
               </div>
               <div className="mt-3 flex items-center">
-                {comment.writer.image &&
-                comment.writer.image.startsWith('http') ? (
-                  <div className="h-[32px] w-[32px] overflow-hidden rounded-full">
-                    <Image
-                      src={comment.writer.image}
-                      alt="프로필"
-                      width={32}
-                      height={32}
-                      className="h-full w-full object-cover"
-                    />
-                  </div>
-                ) : (
-                  <Image
-                    src={profile}
-                    alt="기본 프로필"
-                    width={32}
-                    height={32}
-                    className="rounded-full border-[2px] border-gray-200/10 bg-b-secondary"
-                  />
-                )}
+                <Image
+                  src={
+                    comment.writer.image?.startsWith('http')
+                      ? comment.writer.image
+                      : profile
+                  }
+                  alt="프로필"
+                  width={32}
+                  height={32}
+                  className="h-[32px] w-[32px] rounded-full border-[2px] border-gray-200/10 bg-b-secondary object-cover"
+                />
+
                 <p className="border-r border-gray-700 px-3 text-[14px]">
                   {comment.writer.nickname}
                 </p>

--- a/app/boards/[articleId]/Comments.tsx
+++ b/app/boards/[articleId]/Comments.tsx
@@ -178,13 +178,15 @@ export default function Comment() {
               <div className="mt-3 flex items-center">
                 {comment.writer.image &&
                 comment.writer.image.startsWith('http') ? (
-                  <Image
-                    src={comment.writer.image}
-                    alt="프로필"
-                    width={32}
-                    height={32}
-                    className="rounded-full"
-                  />
+                  <div className="h-[32px] w-[32px] overflow-hidden rounded-full">
+                    <Image
+                      src={comment.writer.image}
+                      alt="프로필"
+                      width={32}
+                      height={32}
+                      className="h-full w-full object-cover"
+                    />
+                  </div>
                 ) : (
                   <Image
                     src={profile}

--- a/app/boards/[articleId]/page.tsx
+++ b/app/boards/[articleId]/page.tsx
@@ -11,7 +11,7 @@ import PostActionDropdown from '@/app/boards/PostActionDropdown';
 import LikeButton from '@/app/boards/LikeButton';
 import useUserStore from '@/app/stores/userStore';
 import Comment from './Comments';
-import profile from '@/public/images/icons/icon-base-user.svg';
+
 import Loading from '@/app/components/Loading';
 
 export default function ArticleDetail() {
@@ -78,24 +78,6 @@ export default function ArticleDetail() {
 
       <div className="mt-4 flex w-full items-center justify-between text-[14px]">
         <div className="flex items-center space-x-2">
-          {/* 작성자 프로필 이미지 */}
-          {article.writer.image && article.writer.image.startsWith('http') ? (
-            <Image
-              src={article.writer.image}
-              alt="프로필"
-              width={32}
-              height={32}
-              className="rounded-full border-[2px] border-gray-200/10 bg-b-secondary"
-            />
-          ) : (
-            <Image
-              src={profile}
-              alt="기본 프로필"
-              width={32}
-              height={32}
-              className="rounded-full border-[2px] border-gray-200/10 bg-b-secondary"
-            />
-          )}
           <p className="pr-3">{article.writer.nickname}</p>
           <span className="h-4 border-l border-gray-700"></span>
           <p className="text-t-secondary">

--- a/app/boards/best/page.tsx
+++ b/app/boards/best/page.tsx
@@ -3,6 +3,7 @@
 import CardList from '../CardList';
 import bestIcon from '@/public/images/icons/ic_medal.svg';
 import Image from 'next/image';
+import { Suspense } from 'react';
 
 export default function BestPage() {
   return (
@@ -14,11 +15,13 @@ export default function BestPage() {
       />
       <p className="pb-8 text-[30px] font-semibold">베스트 게시글</p>
       <div className="w-full">
-        <CardList
-          keyword=""
-          orderBy="like"
-          hideItem={true}
-        />
+        <Suspense fallback={<></>}>
+          <CardList
+            keyword=""
+            orderBy="like"
+            hideItem={true}
+          />
+        </Suspense>
       </div>
     </div>
   );

--- a/app/boards/best/page.tsx
+++ b/app/boards/best/page.tsx
@@ -13,11 +13,13 @@ export default function BestPage() {
         className="h-auto w-[100px] pb-1"
       />
       <p className="pb-8 text-[30px] font-semibold">베스트 게시글</p>
-      <CardList
-        keyword=""
-        orderBy="like"
-        hideItem={true}
-      />
+      <div className="w-full">
+        <CardList
+          keyword=""
+          orderBy="like"
+          hideItem={true}
+        />
+      </div>
     </div>
   );
 }

--- a/app/boards/page.tsx
+++ b/app/boards/page.tsx
@@ -3,7 +3,7 @@
 import BestCard from './BestCardList';
 import CardList from './CardList';
 import SearchBar from './SearchBar';
-import { useState } from 'react';
+import { Suspense, useState } from 'react';
 import Link from 'next/link';
 import Button from '@/app/components/Button';
 
@@ -28,7 +28,9 @@ export default function Boards() {
         </div>
         <BestCard />
         <SearchBar onSearch={handleSearch} />
-        <CardList keyword={searchKeyword} />
+        <Suspense fallback={<></>}>
+          <CardList keyword={searchKeyword} />
+        </Suspense>
       </div>
 
       <div className="right fixed bottom-20 right-[calc(50%-45%)] z-50 sm:right-[calc(50%-45%)] lg:right-[calc(50%-32.5%)]">


### PR DESCRIPTION
## 📌 Related Issue
- Closed #121 

## 🧾 작업 사항
- [x] 댓글 프로필 수정
- [x] 게시글 작성자 프로필 제거
- [x] 상세 페이지에서 뒤로 갔을 때 페이지 번호가 유지될 수 있게 수정
- [x] 스켈레톤

## 📚 리뷰 포인트
- 댓글 프로필이 갑자기 타원으로 표시되는 오류가 생겨서 수정했습니다.
-  게시글 작성자는 api를 다시 확인해보니 프로필 이미지를 지원하고 있지 않았습니다...
   * 기존 코드에서는 undefined로 처리되어 기본 프로필이 적용되었기 때문에 오류가 없었던 거 같습니다...
* 게시판 페이지의 베스트 게시글 스켈레톤에서 어려움이 있었습니다.
  * 베스트 카드를 반응형에 맞춰 렌더링하도록 설정했기 때문에 스켈레톤 개수를 고정할 수 없었습니다.
  * 이를 해결하려고 null로 설정했더니 초기 렌더링 시 스켈레톤이 너무 늦게 나타나는 문제가 발생했습니다.
  * 그리드를 사용하면 줄바꿈만 조정되고 카드 개수는 변경되지 않았습니다...
  * 초기 상태를 3개로 하고 useEffect로 조정했더니 처음에 3개가 표시된 후 바뀌는 문제가 발생했습니다...
 
해결 방법을 찾지 못해서 로딩 컴포넌트로 지정했습니다ㅠㅠ...

