### PR TITLE
Feat/122  간편로그인 중간페이지

### DIFF
--- a/app/hooks/useEasySignIn.ts
+++ b/app/hooks/useEasySignIn.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useMutation } from '@tanstack/react-query';
+import { postAuthEasySignIn } from '@/app/api/auth.api';
+import useUserStore from '@/app/stores/userStore';
+import axios from 'axios';
+
+export interface EasySignInPayload {
+  token: string;
+  provider: 'GOOGLE' | 'KAKAO';
+  state?: string;
+  redirectUri?: string;
+}
+
+export const useEasySignIn = () => {
+  const router = useRouter();
+  const { setAccessToken, setRefreshToken, setUser } = useUserStore();
+
+  return useMutation({
+    mutationFn: postAuthEasySignIn,
+    onSuccess: (data) => {
+      const { user, accessToken, refreshToken } = data;
+
+      setAccessToken(accessToken);
+      setRefreshToken(refreshToken);
+      setUser(user);
+      router.push('/');
+    },
+    onError: (error) => {
+      if (axios.isAxiosError(error)) {
+        const errorMessage =
+          error.response?.data?.message ||
+          '오류가 발생했습니다. 다시 시도해주세요.';
+        alert(`간편 로그인 실패: ${errorMessage}`);
+      } else {
+        alert('예기치 못한 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+      }
+      router.push('/login');
+    },
+  });
+};

--- a/app/oauth/EasyLoginLoadingPage.tsx
+++ b/app/oauth/EasyLoginLoadingPage.tsx
@@ -15,7 +15,7 @@ export default function EasyLoginLoadingPage({
 }: EasyLoginLoadingPageProps) {
   return (
     <div className="flex w-full flex-col items-center justify-center gap-4 py-40 sm:gap-6">
-      <div className="space-y-4 text-center sm:space-y-6">
+      <div className="text-center">
         <div className="flex items-center gap-2">
           <div className="relative h-10 w-10">
             <Image
@@ -29,9 +29,6 @@ export default function EasyLoginLoadingPage({
           <p className="text-2xl font-semibold sm:text-3xl">
             {`${loginType[type].name} 간편 로그인`}
           </p>
-        </div>
-        <div className="space-y-1 text-xs sm:text-md">
-          <p>처리중입니다. 잠시만 기다려주세요...</p>
         </div>
       </div>
       <Loading />

--- a/app/oauth/EasyLoginLoadingPage.tsx
+++ b/app/oauth/EasyLoginLoadingPage.tsx
@@ -1,0 +1,38 @@
+import Image from 'next/image';
+import Loading from '../components/Loading';
+
+interface EasyLoginLoadingPageProps {
+  type: 'kakao' | 'google';
+}
+
+const loginType = {
+  kakao: { name: '카카오톡', src: '/images/icons/ic_kakaotalk.svg' },
+  google: { name: '구글', src: '/images/icons/ic_google.svg' },
+};
+
+export default function EasyLoginLoadingPage({
+  type,
+}: EasyLoginLoadingPageProps) {
+  return (
+    <div className="flex w-full flex-col items-center justify-center gap-4 py-40 sm:gap-6">
+      <div className="space-y-4 text-center sm:space-y-6">
+        <div className="flex items-center gap-2">
+          <div className="relative h-8 w-8 sm:h-10 sm:w-10">
+            <Image
+              src={loginType[type].src}
+              alt=""
+              fill
+            />
+          </div>
+          <p className="text-2xl font-semibold sm:text-3xl">
+            {`${loginType[type].name} 간편 로그인`}
+          </p>
+        </div>
+        <div className="space-y-1 text-xs sm:text-md">
+          <p>처리중입니다. 잠시만 기다려주세요...</p>
+        </div>
+      </div>
+      <Loading />
+    </div>
+  );
+}

--- a/app/oauth/EasyLoginLoadingPage.tsx
+++ b/app/oauth/EasyLoginLoadingPage.tsx
@@ -17,11 +17,13 @@ export default function EasyLoginLoadingPage({
     <div className="flex w-full flex-col items-center justify-center gap-4 py-40 sm:gap-6">
       <div className="space-y-4 text-center sm:space-y-6">
         <div className="flex items-center gap-2">
-          <div className="relative h-8 w-8 sm:h-10 sm:w-10">
+          <div className="relative h-10 w-10">
             <Image
               src={loginType[type].src}
               alt=""
-              fill
+              width={32}
+              height={32}
+              className="sm:h-10 sm:w-10"
             />
           </div>
           <p className="text-2xl font-semibold sm:text-3xl">

--- a/app/oauth/google/page.tsx
+++ b/app/oauth/google/page.tsx
@@ -6,6 +6,7 @@ import { useMutation } from '@tanstack/react-query';
 import { postAuthEasySignIn } from '../../api/auth.api'; // 백엔드와 통신하는 API 함수
 import useUserStore from '@/app/stores/userStore';
 import { useSession } from 'next-auth/react';
+import EasyLoginLoadingPage from '../EasyLoginLoadingPage';
 
 const GoogleCallback = () => {
   const router = useRouter();
@@ -15,7 +16,6 @@ const GoogleCallback = () => {
     useUserStore();
   const [isProcessing, setIsProcessing] = useState(false);
 
-  // 인증 받은 구글 로그인 정보로 서비스에 로그인 요청
   const googleLoginMutation = useMutation({
     mutationFn: postAuthEasySignIn,
     onSuccess: (data) => {
@@ -24,7 +24,6 @@ const GoogleCallback = () => {
       setAccessToken(accessToken);
       setRefreshToken(refreshToken);
       setUser(user);
-      alert('구글 로그인 성공!');
       router.push('/');
     },
     onError: (error) => {
@@ -55,15 +54,24 @@ const GoogleCallback = () => {
 
       if (!jwtToken) {
         alert('JWT 토큰을 찾을 수 없습니다. 다시 로그인해주세요.');
+
+        router.push('/login');
         return;
       }
 
       handleGoogleLogin(jwtToken);
       setIsGoogleLogin(true);
     }
-  }, [status, session, isProcessing, handleGoogleLogin, setIsGoogleLogin]);
+  }, [
+    status,
+    session,
+    isProcessing,
+    router,
+    handleGoogleLogin,
+    setIsGoogleLogin,
+  ]);
 
-  return <div>구글 로그인 처리 중...</div>;
+  return <EasyLoginLoadingPage type="google" />;
 };
 
 export default GoogleCallback;

--- a/app/oauth/google/page.tsx
+++ b/app/oauth/google/page.tsx
@@ -1,47 +1,25 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { useMutation } from '@tanstack/react-query';
-import { postAuthEasySignIn } from '../../api/auth.api'; // 백엔드와 통신하는 API 함수
-import useUserStore from '@/app/stores/userStore';
 import { useSession } from 'next-auth/react';
 import EasyLoginLoadingPage from '../EasyLoginLoadingPage';
+import { useEasySignIn } from '@/app/hooks/useEasySignIn';
+import useUserStore from '@/app/stores/userStore';
 
 const GoogleCallback = () => {
-  const router = useRouter();
   const { data: session, status } = useSession();
-
-  const { setAccessToken, setRefreshToken, setUser, setIsGoogleLogin } =
-    useUserStore();
+  const { setIsGoogleLogin } = useUserStore();
   const [isProcessing, setIsProcessing] = useState(false);
-
-  const googleLoginMutation = useMutation({
-    mutationFn: postAuthEasySignIn,
-    onSuccess: (data) => {
-      const { user, accessToken, refreshToken } = data;
-
-      setAccessToken(accessToken);
-      setRefreshToken(refreshToken);
-      setUser(user);
-      router.push('/');
-    },
-    onError: (error) => {
-      console.error('구글 로그인 실패:', error);
-      alert('구글 로그인에 실패했습니다. 다시 시도해주세요.');
-    },
-  });
+  const easySignInMutation = useEasySignIn();
 
   const handleGoogleLogin = useCallback(
     (token: string) => {
-      googleLoginMutation.mutate({
+      easySignInMutation.mutate({
         token,
         provider: 'GOOGLE',
       });
-
-      console.log(token);
     },
-    [googleLoginMutation]
+    [easySignInMutation]
   );
 
   useEffect(() => {
@@ -49,27 +27,17 @@ const GoogleCallback = () => {
 
     if (status === 'authenticated') {
       setIsProcessing(true);
-
       const jwtToken = session?.idToken;
 
       if (!jwtToken) {
         alert('JWT 토큰을 찾을 수 없습니다. 다시 로그인해주세요.');
-
-        router.push('/login');
         return;
       }
 
       handleGoogleLogin(jwtToken);
       setIsGoogleLogin(true);
     }
-  }, [
-    status,
-    session,
-    isProcessing,
-    router,
-    handleGoogleLogin,
-    setIsGoogleLogin,
-  ]);
+  }, [status, session, isProcessing, handleGoogleLogin, setIsGoogleLogin]);
 
   return <EasyLoginLoadingPage type="google" />;
 };


### PR DESCRIPTION
## 📌 Related Issue
- Closed #122 

## 🧾 작업 사항
- 간편 로그인 api요청을 처리하는 중간 페이지에 간단한 디자인 추가
- 간편 로그인 reac-query 사용 부분을 훅으로 분리
- 로그인 성공 시 alert제거

## 📚 리뷰 포인트
- 간편 로그인은 `postAuthEasySignIn` api를 둘 다 사용하므로 훅을 만들어 코드 중복을 제거하였습니다.
- 간편 로그인 중간 페이지에 간단한 디자인을 추가해 보았습니다. 이상하다면 피드백 주세요!

## 📷 Screenshot/GIF
![image](https://github.com/user-attachments/assets/481ab6d5-be62-4b76-bb4d-51a23b8c5131)

![image](https://github.com/user-attachments/assets/ff313fea-4db0-4b41-83e8-e4189272686d)
