### PR TITLE
Refactor/132  로그인 회원가입 리팩토링

### DIFF
--- a/app/api/auth.api.ts
+++ b/app/api/auth.api.ts
@@ -14,7 +14,6 @@ const postAuthSignIn = async (
   params: AuthParamsType['postAuthSignIn']
 ): Promise<AuthResponseType['postAuthSignIn']> => {
   const response = await instance.post(`auth/signIn`, params);
-  console.log(response.data);
   return response.data;
 };
 

--- a/app/hooks/useEasySignIn.ts
+++ b/app/hooks/useEasySignIn.ts
@@ -4,7 +4,7 @@ import { useRouter } from 'next/navigation';
 import { useMutation } from '@tanstack/react-query';
 import { postAuthEasySignIn } from '@/app/api/auth.api';
 import useUserStore from '@/app/stores/userStore';
-import axios from 'axios';
+import { createErrorHandler } from '../utils/createErrorHandler';
 
 export interface EasySignInPayload {
   token: string;
@@ -27,16 +27,11 @@ export const useEasySignIn = () => {
       setUser(user);
       router.push('/');
     },
-    onError: (error) => {
-      if (axios.isAxiosError(error)) {
-        const errorMessage =
-          error.response?.data?.message ||
-          '오류가 발생했습니다. 다시 시도해주세요.';
-        alert(`간편 로그인 실패: ${errorMessage}`);
-      } else {
-        alert('예기치 못한 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
-      }
-      router.push('/login');
-    },
+    onError: createErrorHandler({
+      prefixMessage: '간편 로그인 실패',
+      onAfter: () => {
+        router.push('/login');
+      },
+    }),
   });
 };

--- a/app/login/EasyLogin.tsx
+++ b/app/login/EasyLogin.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { signIn } from 'next-auth/react';
 import Image from 'next/image';
+
+import { signIn } from 'next-auth/react';
 import { toast } from 'react-toastify';
 
 export default function EasyLogin({ page }: { page: 'login' | 'signup' }) {

--- a/app/login/EasyLogin.tsx
+++ b/app/login/EasyLogin.tsx
@@ -8,12 +8,16 @@ import { toast } from 'react-toastify';
 export default function EasyLogin({ page }: { page: 'login' | 'signup' }) {
   const handleKakaoLogin = () => {
     if (!window.Kakao) {
-      toast.error('카카오 SDK가 로드되지 않았습니다.');
+      toast.error(
+        '카카오 로그인을 사용할 수 없습니다. 사이트 재접속 후 다시 시도해주세요.'
+      );
 
       return;
     }
     if (!window.Kakao.Auth) {
-      toast.error('카카오 Auth 모듈이 로드되지 않았습니다.');
+      toast.error(
+        '카카오 로그인 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.'
+      );
 
       return;
     }

--- a/app/login/EasyLogin.tsx
+++ b/app/login/EasyLogin.tsx
@@ -2,31 +2,31 @@
 
 import { signIn } from 'next-auth/react';
 import Image from 'next/image';
+import { toast } from 'react-toastify';
 
 export default function EasyLogin({ page }: { page: 'login' | 'signup' }) {
   const handleKakaoLogin = () => {
     if (!window.Kakao) {
-      alert('카카오 SDK가 로드되지 않았습니다.');
+      toast.error('카카오 SDK가 로드되지 않았습니다.');
+
       return;
     }
     if (!window.Kakao.Auth) {
-      alert('카카오 Auth 모듈이 로드되지 않았습니다.');
+      toast.error('카카오 Auth 모듈이 로드되지 않았습니다.');
+
       return;
     }
 
-    // CSRF 방지를 위한 랜덤 값
-    // 인가 코드와 함께 돌려받았을 때 일치 여부를 검증
     const state = Math.random().toString(36).substring(2, 10);
 
     window.Kakao.Auth.authorize({
-      redirectUri: process.env.NEXT_PUBLIC_KAKAO_LOGIN_REDIRECT_URI!, // 인가 코드 받을 페이지
+      redirectUri: process.env.NEXT_PUBLIC_KAKAO_LOGIN_REDIRECT_URI!,
       state: state,
     });
 
-    localStorage.setItem('kakao_state', state); // 이후 검증을 위해 저장
+    localStorage.setItem('kakao_state', state);
   };
 
-  // 구글 로그인 창으로 이동
   const handleGoogleLogin = () => {
     signIn('google', {
       callbackUrl: '/oauth/google',

--- a/app/login/LoginForm.tsx
+++ b/app/login/LoginForm.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import React, { useCallback, useEffect, useState } from 'react';
+
+import type { LoginFormDataType } from '@app/types/auth';
 import InputField from '@components/InputField';
 import Button from '@components/Button';
-import { validateEmail, validatePassword } from '@/app/utils/formValidators';
-import { LoginFormDataType } from '../types/auth';
-import ResetPasswordEmailModal from './ResetPasswordEmailModal';
+import { validateEmail, validatePassword } from '@app/utils/formValidators';
+import ResetPasswordEmailModal from '@app/login/ResetPasswordEmailModal';
 
 interface LoginFormProps {
   onSubmit: (formData: LoginFormDataType) => void;
@@ -29,7 +30,6 @@ export default function LoginForm({
       password: validatePassword(formData.password.trim()) || '',
     };
 
-    // 에러가 하나라도 있으면 false 반환
     setIsValidated(!Object.values(newErrors).some((error) => error));
   }, [formData]);
 

--- a/app/login/ResetPasswordEmailModal.tsx
+++ b/app/login/ResetPasswordEmailModal.tsx
@@ -1,12 +1,14 @@
 import { useState } from 'react';
-import InputField from '../components/InputField';
-import Modal, { ModalFooter } from '../components/Modal';
-import { validateEmail } from '../utils/formValidators';
-import Button from '../components/Button';
+
 import { useMutation } from '@tanstack/react-query';
-import { postUserSendRestPasswordEmail } from '../api/user.api';
-import { UserResponseType } from '../types/user';
-import axios from 'axios';
+
+import type { UserResponseType } from '@app/types/user';
+import { postUserSendRestPasswordEmail } from '@api/user.api';
+import InputField from '@components/InputField';
+import Modal, { ModalFooter } from '@components/Modal';
+import Button from '@components/Button';
+import { validateEmail } from '@utils/formValidators';
+import { createErrorHandler } from '@utils/createErrorHandler';
 
 interface ResetPasswordEmailModalProps {
   isOpen: boolean;
@@ -25,16 +27,7 @@ export default function ResetPasswordEmailModal({
       const { message } = data;
       alert(message);
     },
-    onError: (error) => {
-      if (axios.isAxiosError(error)) {
-        const errorMessage =
-          error.response?.data?.message ||
-          '오류가 발생했습니다. 다시 시도해주세요.';
-        alert(`로그인 실패: ${errorMessage}`);
-      } else {
-        alert('예기치 못한 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
-      }
-    },
+    onError: createErrorHandler({ prefixMessage: '로그인 실패' }),
   });
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,15 +1,17 @@
 'use client';
 
 import React, { useEffect } from 'react';
-import LoginForm from '@/app/login/LoginForm';
-import { postAuthSignIn } from '../api/auth.api';
-import { useMutation } from '@tanstack/react-query';
-import useUserStore from '../stores/userStore';
-import { AuthResponseType, LoginFormDataType } from '../types/auth';
 import Link from 'next/link';
-import EasyLogin from './EasyLogin';
 import { useRouter } from 'next/navigation';
-import { createErrorHandler } from '../utils/createErrorHandler';
+
+import { useMutation } from '@tanstack/react-query';
+
+import type { AuthResponseType, LoginFormDataType } from '@app/types/auth';
+import LoginForm from '@app/login/LoginForm';
+import { postAuthSignIn } from '@api/auth.api';
+import useUserStore from '@stores/userStore';
+import EasyLogin from '@app/login/EasyLogin';
+import { createErrorHandler } from '@utils/createErrorHandler';
 
 export default function LoginPage() {
   const { user, setAccessToken, setRefreshToken, setUser } = useUserStore();

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -6,10 +6,10 @@ import { postAuthSignIn } from '../api/auth.api';
 import { useMutation } from '@tanstack/react-query';
 import useUserStore from '../stores/userStore';
 import { AuthResponseType, LoginFormDataType } from '../types/auth';
-import axios from 'axios';
 import Link from 'next/link';
 import EasyLogin from './EasyLogin';
 import { useRouter } from 'next/navigation';
+import { createErrorHandler } from '../utils/createErrorHandler';
 
 export default function LoginPage() {
   const { user, setAccessToken, setRefreshToken, setUser } = useUserStore();
@@ -28,19 +28,9 @@ export default function LoginPage() {
       setAccessToken(accessToken);
       setRefreshToken(refreshToken);
       setUser(user);
-      alert('로그인에 성공했습니다!');
       router.push('/');
     },
-    onError: (error) => {
-      if (axios.isAxiosError(error)) {
-        const errorMessage =
-          error.response?.data?.message ||
-          '오류가 발생했습니다. 다시 시도해주세요.';
-        alert(`로그인 실패: ${errorMessage}`);
-      } else {
-        alert('예기치 못한 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
-      }
-    },
+    onError: createErrorHandler({ prefixMessage: '로그인 실패' }),
   });
 
   const handleLoginSubmit = (formData: LoginFormDataType) => {

--- a/app/oauth/EasyLoginLoadingPage.tsx
+++ b/app/oauth/EasyLoginLoadingPage.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
-import Loading from '../components/Loading';
+
+import Loading from '@components/Loading';
 
 interface EasyLoginLoadingPageProps {
   type: 'kakao' | 'google';

--- a/app/oauth/google/page.tsx
+++ b/app/oauth/google/page.tsx
@@ -44,7 +44,7 @@ const GoogleCallback = () => {
       const jwtToken = session?.idToken;
 
       if (!jwtToken) {
-        toast.error('JWT 토큰을 찾을 수 없습니다. 다시 로그인해주세요.');
+        toast.error('구글 로그인 중 문제가 발생했습니다. 다시 로그인해주세요.');
         router.push('/login');
 
         return;

--- a/app/oauth/google/page.tsx
+++ b/app/oauth/google/page.tsx
@@ -1,10 +1,13 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
+
 import { useSession } from 'next-auth/react';
-import EasyLoginLoadingPage from '../EasyLoginLoadingPage';
-import { useEasySignIn } from '@/app/hooks/useEasySignIn';
-import useUserStore from '@/app/stores/userStore';
+import { toast } from 'react-toastify';
+
+import EasyLoginLoadingPage from '@app/oauth/EasyLoginLoadingPage';
+import { useEasySignIn } from '@hooks/useEasySignIn';
+import useUserStore from '@app/stores/userStore';
 
 const GoogleCallback = () => {
   const { data: session, status } = useSession();
@@ -30,7 +33,7 @@ const GoogleCallback = () => {
       const jwtToken = session?.idToken;
 
       if (!jwtToken) {
-        alert('JWT 토큰을 찾을 수 없습니다. 다시 로그인해주세요.');
+        toast.error('JWT 토큰을 찾을 수 없습니다. 다시 로그인해주세요.');
         return;
       }
 

--- a/app/oauth/google/page.tsx
+++ b/app/oauth/google/page.tsx
@@ -8,11 +8,15 @@ import { toast } from 'react-toastify';
 import EasyLoginLoadingPage from '@app/oauth/EasyLoginLoadingPage';
 import { useEasySignIn } from '@hooks/useEasySignIn';
 import useUserStore from '@app/stores/userStore';
+import { useRouter } from 'next/navigation';
 
 const GoogleCallback = () => {
-  const { data: session, status } = useSession();
   const { setIsGoogleLogin } = useUserStore();
   const [isProcessing, setIsProcessing] = useState(false);
+
+  const { data: session, status } = useSession();
+  const router = useRouter();
+
   const easySignInMutation = useEasySignIn();
 
   const handleGoogleLogin = useCallback(
@@ -28,19 +32,36 @@ const GoogleCallback = () => {
   useEffect(() => {
     if (isProcessing) return;
 
+    if (status === 'unauthenticated') {
+      toast.error('로그인 상태가 아닙니다. 다시 로그인해주세요.');
+      router.push('/login');
+
+      return;
+    }
+
     if (status === 'authenticated') {
       setIsProcessing(true);
       const jwtToken = session?.idToken;
 
       if (!jwtToken) {
         toast.error('JWT 토큰을 찾을 수 없습니다. 다시 로그인해주세요.');
+        router.push('/login');
+
         return;
       }
 
       handleGoogleLogin(jwtToken);
       setIsGoogleLogin(true);
+    } else {
     }
-  }, [status, session, isProcessing, handleGoogleLogin, setIsGoogleLogin]);
+  }, [
+    status,
+    session,
+    isProcessing,
+    handleGoogleLogin,
+    setIsGoogleLogin,
+    router,
+  ]);
 
   return <EasyLoginLoadingPage type="google" />;
 };

--- a/app/oauth/kakao/page.tsx
+++ b/app/oauth/kakao/page.tsx
@@ -1,8 +1,11 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import EasyLoginLoadingPage from '../EasyLoginLoadingPage';
-import { useEasySignIn } from '@/app/hooks/useEasySignIn';
+
+import { toast } from 'react-toastify';
+
+import EasyLoginLoadingPage from '@app/oauth/EasyLoginLoadingPage';
+import { useEasySignIn } from '@hooks/useEasySignIn';
 
 const KakaoCallback = () => {
   const [isProcessing, setIsProcessing] = useState(false);
@@ -30,12 +33,14 @@ const KakaoCallback = () => {
     const storedState = localStorage.getItem('kakao_state');
 
     if (!code) {
-      alert('⚠️ 인가 코드가 없습니다. 다시 로그인해주세요.');
+      toast.error('⚠️ 인가 코드가 없습니다. 다시 로그인해주세요.');
+
       return;
     }
 
     if (!receivedState || receivedState !== storedState) {
-      alert('⚠️ CSRF 공격이 감지되었습니다. 다시 로그인해주세요.');
+      toast.error('⚠️ CSRF 공격이 감지되었습니다. 다시 로그인해주세요.');
+
       return;
     }
 

--- a/app/oauth/kakao/page.tsx
+++ b/app/oauth/kakao/page.tsx
@@ -1,15 +1,19 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { toast } from 'react-toastify';
 
 import EasyLoginLoadingPage from '@app/oauth/EasyLoginLoadingPage';
 import { useEasySignIn } from '@hooks/useEasySignIn';
+import { useRouter } from 'next/navigation';
 
 const KakaoCallback = () => {
   const [isProcessing, setIsProcessing] = useState(false);
   const easySignInMutation = useEasySignIn();
+
+  const router = useRouter();
+  const hasShownError = useRef(false);
 
   const handleKakaoLogin = useCallback(
     (code: string, receivedState: string) => {
@@ -25,7 +29,7 @@ const KakaoCallback = () => {
   );
 
   useEffect(() => {
-    if (isProcessing) return;
+    if (isProcessing || hasShownError.current) return;
 
     const urlParams = new URL(window.location.href).searchParams;
     const code = urlParams.get('code');
@@ -33,19 +37,27 @@ const KakaoCallback = () => {
     const storedState = localStorage.getItem('kakao_state');
 
     if (!code) {
-      toast.error('⚠️ 인가 코드가 없습니다. 다시 로그인해주세요.');
+      toast.error(
+        '⚠️ 인가 코드가 없습니다. 카카오톡 간편 로그인을 다시 진행해주세요.'
+      );
+      hasShownError.current = true;
 
+      router.push('/login');
       return;
     }
 
     if (!receivedState || receivedState !== storedState) {
-      toast.error('⚠️ CSRF 공격이 감지되었습니다. 다시 로그인해주세요.');
+      toast.error(
+        '⚠️ CSRF 공격이 감지되었습니다. 카카오톡 간편 로그인을 다시 진행해주세요.'
+      );
 
+      hasShownError.current = true;
+      router.push('/login');
       return;
     }
 
     handleKakaoLogin(code, receivedState);
-  }, [handleKakaoLogin, isProcessing]);
+  }, [handleKakaoLogin, isProcessing, router]);
 
   return <EasyLoginLoadingPage type="kakao" />;
 };

--- a/app/signup/SignupForm.tsx
+++ b/app/signup/SignupForm.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 import React, { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+
+import type { SignUpFormDataType } from '@app/types/auth';
 import InputField from '@components/InputField';
 import Button from '@components/Button';
 import {
@@ -8,9 +11,7 @@ import {
   validateEmail,
   validateName,
   validatePassword,
-} from '@/app/utils/formValidators';
-import { SignUpFormDataType } from '../types/auth';
-import Link from 'next/link';
+} from '@utils/formValidators';
 
 interface SignupFormProps {
   onSubmit: (formData: SignUpFormDataType) => void;
@@ -27,7 +28,6 @@ export default function SignupForm({
   },
 }: SignupFormProps) {
   const [formData, setFormData] = useState(initialFormData);
-
   const [isValidated, setIsValidated] = useState(false);
 
   const validateForm = useCallback(() => {
@@ -39,7 +39,6 @@ export default function SignupForm({
         validateConfirmPassword(formData.confirmPassword.trim()) || '',
     };
 
-    // 에러가 하나라도 있으면 false 반환
     setIsValidated(!Object.values(newErrors).some((error) => error));
   }, [formData]);
 

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -4,10 +4,11 @@ import React from 'react';
 import SignupForm from '@/app/signup/SignupForm';
 import { postAuthSignUp } from '../api/auth.api';
 import { useMutation } from '@tanstack/react-query';
-import axios from 'axios';
 import { SignUpFormDataType } from '../types/auth';
 import { useRouter } from 'next/navigation';
 import EasyLogin from '../login/EasyLogin';
+import { createErrorHandler } from '../utils/createErrorHandler';
+import { toast } from 'react-toastify';
 
 export default function SignupPage() {
   const router = useRouter();
@@ -15,18 +16,10 @@ export default function SignupPage() {
   const signupMutation = useMutation({
     mutationFn: postAuthSignUp,
     onSuccess: () => {
-      alert('회원가입에 성공했습니다!');
+      toast('회원가입에 성공했습니다!');
       router.push('/login');
     },
-    onError: (error) => {
-      if (axios.isAxiosError(error) && error.response) {
-        const errorMessage =
-          error.response.data.message || '회원가입 중 오류가 발생했습니다.';
-        alert(`회원가입 실패: ${errorMessage}`);
-      } else {
-        alert('예기치 못한 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
-      }
-    },
+    onError: createErrorHandler({ prefixMessage: '회원가입 실패' }),
   });
 
   const handleSignupSubmit = (formData: SignUpFormDataType) => {

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -6,8 +6,8 @@ import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
 import { useMutation } from '@tanstack/react-query';
 
-import { postAuthSignUp } from '@api/auth.api';
 import type { SignUpFormDataType } from '@app/types/auth';
+import { postAuthSignUp } from '@api/auth.api';
 import EasyLogin from '@app/login/EasyLogin';
 import { createErrorHandler } from '@utils/createErrorHandler';
 import SignupForm from '@/app/signup/SignupForm';

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,14 +1,16 @@
 'use client';
 
 import React from 'react';
-import SignupForm from '@/app/signup/SignupForm';
-import { postAuthSignUp } from '../api/auth.api';
-import { useMutation } from '@tanstack/react-query';
-import { SignUpFormDataType } from '../types/auth';
 import { useRouter } from 'next/navigation';
-import EasyLogin from '../login/EasyLogin';
-import { createErrorHandler } from '../utils/createErrorHandler';
+
 import { toast } from 'react-toastify';
+import { useMutation } from '@tanstack/react-query';
+
+import { postAuthSignUp } from '@api/auth.api';
+import type { SignUpFormDataType } from '@app/types/auth';
+import EasyLogin from '@app/login/EasyLogin';
+import { createErrorHandler } from '@utils/createErrorHandler';
+import SignupForm from '@/app/signup/SignupForm';
 
 export default function SignupPage() {
   const router = useRouter();

--- a/app/utils/createErrorHandler.ts
+++ b/app/utils/createErrorHandler.ts
@@ -1,0 +1,24 @@
+import axios from 'axios';
+import { toast } from 'react-toastify';
+
+interface ErrorHandlerOptions {
+  prefixMessage?: string;
+  onDisplay?: (message: string) => void;
+}
+
+export function createErrorHandler(options?: ErrorHandlerOptions) {
+  const {
+    prefixMessage = '에러',
+    onDisplay = (message: string) => toast.error(message),
+  } = options || {};
+
+  return (error: unknown) => {
+    let message: string = '오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+
+    if (axios.isAxiosError(error) && error.response?.data?.message) {
+      message = error.response?.data?.message;
+    }
+
+    onDisplay(`${prefixMessage}: ${message}`);
+  };
+}

--- a/app/utils/createErrorHandler.ts
+++ b/app/utils/createErrorHandler.ts
@@ -2,16 +2,18 @@ import axios from 'axios';
 import { toast } from 'react-toastify';
 
 interface ErrorHandlerOptions {
-  prefixMessage?: string;
-  defaultErrorMessage?: string;
-  onDisplay?: (message: string) => void;
+  prefixMessage?: string; // 에러 상황 설명 (ex: 로그인 실패, 회원가입 실패)
+  defaultErrorMessage?: string; // 서버 응답에 에러메시지가 없는 경우 사용할 메시지
+  onDisplay?: (message: string) => void; // 에러 출력 방법 (ex: console.error, alert)
+  onAfter?: (error: unknown) => void; // 에러 출력 후 동작
 }
 
 export function createErrorHandler(options?: ErrorHandlerOptions) {
   const {
     prefixMessage = '에러',
-    onDisplay = (message: string) => toast.error(message),
+    onDisplay = (message: string) => toast.error(message), // 에러 출력 기본값은 toast.error
     defaultErrorMessage = '오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+    onAfter,
   } = options || {};
 
   return (error: unknown) => {
@@ -22,5 +24,9 @@ export function createErrorHandler(options?: ErrorHandlerOptions) {
     }
 
     onDisplay(`${prefixMessage}: ${message}`);
+
+    if (onAfter) {
+      onAfter(error);
+    }
   };
 }

--- a/app/utils/createErrorHandler.ts
+++ b/app/utils/createErrorHandler.ts
@@ -3,6 +3,7 @@ import { toast } from 'react-toastify';
 
 interface ErrorHandlerOptions {
   prefixMessage?: string;
+  defaultErrorMessage?: string;
   onDisplay?: (message: string) => void;
 }
 
@@ -10,10 +11,11 @@ export function createErrorHandler(options?: ErrorHandlerOptions) {
   const {
     prefixMessage = '에러',
     onDisplay = (message: string) => toast.error(message),
+    defaultErrorMessage = '오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
   } = options || {};
 
   return (error: unknown) => {
-    let message: string = '오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+    let message: string = defaultErrorMessage;
 
     if (axios.isAxiosError(error) && error.response?.data?.message) {
       message = error.response?.data?.message;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     "paths": {
       "@/*": ["./*"],
       "@app/*": ["./app/*"],
+      "@app/types/*": ["./app/types/*"],
       "@components/*": ["./app/components/*"],
       "@api/*": ["./app/api/*"],
       "@hooks/*": ["./app/hooks/*"],
@@ -30,7 +31,6 @@
       "@styles/*": ["./styles/*"],
       "@images/*": ["./public/images/*"],
       "@stores/*": ["./app/stores/*"],
-      "@types/*": ["./app/types/*"],
       "@constants/*": ["./app/constants/*"]
     }
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,6 @@
     "paths": {
       "@/*": ["./*"],
       "@app/*": ["./app/*"],
-      "@app/types/*": ["./app/types/*"],
       "@components/*": ["./app/components/*"],
       "@api/*": ["./app/api/*"],
       "@hooks/*": ["./app/hooks/*"],
@@ -31,6 +30,7 @@
       "@styles/*": ["./styles/*"],
       "@images/*": ["./public/images/*"],
       "@stores/*": ["./app/stores/*"],
+      "@types/*": ["./app/types/*"],
       "@constants/*": ["./app/constants/*"]
     }
   },


### PR DESCRIPTION
## 📌 Related Issue
- Closed #132 

## 🧾 작업 사항
- 로그인/회원가입 페이지 리팩토링
- `import`구문 컨벤션 반영
- `useMutation`의 `onError`에 사용할 에러 핸들러 유틸리티 함수 구현 (`utils/createErrorHandler`)
- `toast` 적용
- 주석 제거
- 일부 에러 처리
  - 카카오톡 api 요청 페이지에서 인가코드가 없어나 잘못되었을 경우, 토스트가 2번씩 나타나던 오류를 해결

## 📚 리뷰 포인트
- `useMuation`을 사용하는 경우, 저는 같은 로직을 여러 번 반복 사용하고 있어서 이 부분을 유틸리티 함수로 분리하여 만들었습니다. 살펴보시고 사용 가능하신 경우 중복 코드가 줄어들 것으로 기대합니다.
- 현재 절대 경로 별칭 중 `@types`에 문제가 있습니다. 타입스크립트의 예약어라 절대 경로로 활용할 수 없는 문제가 있어서, `@app/types`로 사용하였습니다. 또한 파일 `import`시 자동완성으로 절대 경로가 `@/`으로 경우가 있으셨을 텐데, 제가 `path`의 순서를 잘못 입력해서 그렇습니다. 곧 수정해서 다시 PR올리겠습니다.
- 토스트가 페이지 전환하면 당연히 사라질 것으로 생각하고 이 부분을 어떻게 할지 고민했는데 사라지지 않고 유지되더라구요! 덕분이 일이 줄었습니다!

## 📷 Screenshot/GIF
- 인가 코드 없이 간편 로그인 페이지 접근 시, 토스트를 띄우며 로그인 페이지로 이동

https://github.com/user-attachments/assets/501a8afa-a851-4774-a2fe-5b8baeb6b46a

