### PR TITLE
 Chore/127--type alias 수정(순서 및 @types변경)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,8 +20,7 @@
     ],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"],
-      "@app/*": ["./app/*"],
+      "@app/types/*": ["./app/types/*"],
       "@components/*": ["./app/components/*"],
       "@api/*": ["./app/api/*"],
       "@hooks/*": ["./app/hooks/*"],
@@ -30,8 +29,9 @@
       "@styles/*": ["./styles/*"],
       "@images/*": ["./public/images/*"],
       "@stores/*": ["./app/stores/*"],
-      "@types/*": ["./app/types/*"],
-      "@constants/*": ["./app/constants/*"]
+      "@constants/*": ["./app/constants/*"],
+      "@/*": ["./*"],
+      "@app/*": ["./app/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## 📌 Related Issue
- #127

## 🧾 작업 사항
- `path` 순서 수정
- `@types` -> `@app/types`로 변경


## 📚 리뷰 포인트
- `@types`가 예약어라 별칭으로 사용할 수 없는 문제가 있어서 `@app/types`로 변경했습니다. 
- 파일 `import`시 `@app`이 아닌 `@/app`으로 자동완성 되는 문제를 `path`의 순서를 변경하여 해결했습니다.
- 혹시 자동 완성으로 별칭이 적용되지 않는 분이 계신다면, `settings.json`에서 이하의 옵션을 추가하고 에디터를 재실행해보시기 바랍니다.
  ```js
   "typescript.preferences.importModuleSpecifier": "non-relative",
  ```
