### PR TITLE
Refactor/132  로그인 회원가입 리펙토링

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -40,11 +40,9 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="flex h-full flex-col items-center justify-start bg-b-primary px-4 py-6 sm:pt-[100px]">
-      <h2 className="mb-6 text-center text-2xl font-medium lg:text-4xl">
-        로그인
-      </h2>
-      <div className="w-full max-w-[460px] space-y-12 sm:pt-[80px]">
+    <div className="flex min-h-screen flex-col items-center bg-b-primary px-4 pt-[10vh] sm:pt-[15vh]">
+      <h2 className="text-center text-2xl font-medium lg:text-4xl">로그인</h2>
+      <div className="w-full max-w-[460px] space-y-12 pt-[4vh] sm:pt-[6vh]">
         <div className="flex flex-col gap-6">
           <LoginForm onSubmit={handleLoginSubmit} />
           <div className="text-center font-medium">

--- a/app/oauth/kakao/page.tsx
+++ b/app/oauth/kakao/page.tsx
@@ -36,23 +36,35 @@ const KakaoCallback = () => {
     const receivedState = urlParams.get('state');
     const storedState = localStorage.getItem('kakao_state');
 
+    const redirectWithMessage = (message: string, error = true) => {
+      if (error) {
+        toast.error(message);
+      } else {
+        toast(message);
+      }
+      hasShownError.current = true;
+      router.push('/login');
+    };
+
     if (!code) {
-      toast.error(
+      redirectWithMessage(
         '⚠️ 인가 코드가 없습니다. 카카오톡 간편 로그인을 다시 진행해주세요.'
       );
-      hasShownError.current = true;
-
-      router.push('/login');
       return;
     }
 
-    if (!receivedState || receivedState !== storedState) {
-      toast.error(
+    if (!storedState) {
+      redirectWithMessage(
+        '카카오 브라우저로 접속하셨습니다. 카카오 로그인을 다시 진행해주세요.',
+        false
+      );
+      return;
+    }
+
+    if (receivedState !== storedState) {
+      redirectWithMessage(
         '⚠️ CSRF 공격이 감지되었습니다. 카카오톡 간편 로그인을 다시 진행해주세요.'
       );
-
-      hasShownError.current = true;
-      router.push('/login');
       return;
     }
 

--- a/app/signup/SignupForm.tsx
+++ b/app/signup/SignupForm.tsx
@@ -113,7 +113,7 @@ export default function SignupForm({
         </div>
         <Link
           href="/login"
-          className="block cursor-pointer text-right text-md text-emerald-500 underline hover:opacity-50 sm:text-lg"
+          className="block w-fit cursor-pointer place-self-end text-right text-md text-emerald-500 underline hover:opacity-50 sm:text-lg"
         >
           로그인 페이지로
         </Link>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,8 +30,8 @@
       "@images/*": ["./public/images/*"],
       "@stores/*": ["./app/stores/*"],
       "@constants/*": ["./app/constants/*"],
-      "@/*": ["./*"],
-      "@app/*": ["./app/*"]
+      "@app/*": ["./app/*"],
+      "@/*": ["./*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## 📌 Related Issue
- Closed #132 

## 🧾 작업 사항
- 회원가입 페이지의 `로그인 이동` 버튼 선택 영역 조정
- 모바일 카카오 로그인 시도 시 안내 토스트 추가

## 📚 리뷰 포인트
- 카카오 로그인을 모바일에서 시도하는 경우, 카카오 브라우저가 열리며 그곳에서 로그인이 시도됩니다. 다만 이 때 브라우저가 달라지며 `localStorage`에 저장된 `state`값을 조회할 수 없게 되어 `CSRF` 경고 토스트가 팝업되고 있었습니다.
- 해결을 시도했으나, 카카오 developers에서 모바일 카카오 로그인 시 로그인만 진행하고 이전 브라우저로 되돌아가거나, 로그인 정보를 전달하는 기능은 제공하지 않고 있었습니다.
- 해서 차선책으로 모바일 카카오 로그인은 카카오 브라우저에서 서비스를 이용하는 것을 전제로 하고, 카카오 브라우저 접속시 `state` 를 비교하여 카카오 브라우저 안내 토스트를 출력하도록 수정했습니다.
  - *로컬 스토리지에서 값을 제거해 테스트를 해보았으나, 배포 후 재확인이 필요합니다.)*
- `state`를 제거하는 방법도 있지만, 일단은 보안 상 있는 기능을 제거하는 것은 꺼려져서 위 방법을 선택했습니다.
- 결론적으로, 모바일 카카오 로그인은 버튼 클릭 후 카카오 브라우저에 접속하여 토스트를 확인한 후 다시 카카오 로그인 버튼을 클릭해야 합니다. 이 경우엔 정상 로그인 처리 되는 것을 확인했습니다.


++ 커밋에 path 수정 커밋이 #143 PR과 중복해서 들어가 있는데, 빠진 줄 알고 다시 넣은 채 이미 push해버려서 되돌릴 수 없었습니다.. (force는 지양해야하니..) 한 쪽 머지 되면 아마 변경사항으로 추적되지 않을 겁니다ㅜ
## 📷 Screenshot/GIF
![image](https://github.com/user-attachments/assets/32052140-c199-42a0-a46f-d962b1df37f9)
