### PR TITLE
Refactor/151  계정설정페이지 리팩토링

### DIFF
--- a/app/hooks/useEasySignIn.ts
+++ b/app/hooks/useEasySignIn.ts
@@ -6,6 +6,8 @@ import { postAuthEasySignIn } from '@/app/api/auth.api';
 import useUserStore from '@/app/stores/userStore';
 import { createErrorHandler } from '../utils/createErrorHandler';
 
+type ProviderType = 'GOOGLE' | 'KAKAO';
+
 export interface EasySignInPayload {
   token: string;
   provider: 'GOOGLE' | 'KAKAO';
@@ -13,9 +15,15 @@ export interface EasySignInPayload {
   redirectUri?: string;
 }
 
-export const useEasySignIn = () => {
+export const useEasySignIn = ({ provider }: { provider: ProviderType }) => {
   const router = useRouter();
-  const { setAccessToken, setRefreshToken, setUser } = useUserStore();
+  const {
+    setAccessToken,
+    setRefreshToken,
+    setUser,
+    setIsKakaoLogin,
+    setIsGoogleLogin,
+  } = useUserStore();
 
   return useMutation({
     mutationFn: postAuthEasySignIn,
@@ -25,6 +33,13 @@ export const useEasySignIn = () => {
       setAccessToken(accessToken);
       setRefreshToken(refreshToken);
       setUser(user);
+
+      if (provider === 'GOOGLE') {
+        setIsGoogleLogin(true);
+      } else if (provider === 'KAKAO') {
+        setIsKakaoLogin(true);
+      }
+
       router.push('/');
     },
     onError: createErrorHandler({

--- a/app/mypage/ConfirnSecessionModal.tsx
+++ b/app/mypage/ConfirnSecessionModal.tsx
@@ -1,5 +1,5 @@
-import Button from '../components/Button';
-import Modal, { ModalFooter } from '../components/Modal';
+import Button from '@components/Button';
+import Modal, { ModalFooter } from '@components/Modal';
 
 interface ConFirmSecessionModalProps {
   isOpen: boolean;

--- a/app/mypage/MyPageForm.tsx
+++ b/app/mypage/MyPageForm.tsx
@@ -7,7 +7,7 @@ import type { UserType } from '@app/types/shared';
 import InputField from '@components/InputField';
 import Button from '@components/Button';
 import ImageUpload from '@components/ImageUpload';
-import { validateName, validateUserUpdated } from '@app/utils/formValidators';
+import { validateNickname, validateUserUpdated } from '@app/utils/formValidators';
 
 export interface MyPageFormProps {
   initialFormData: UserFormDataTypes;
@@ -29,7 +29,7 @@ export default function MyPageForm({
 
   const validateForm = useCallback(() => {
     const trimmedName = formData.nickname.trim();
-    const error = validateName(trimmedName);
+    const error = validateNickname(trimmedName);
     setIsValidated(!error);
   }, [formData.nickname]);
 
@@ -74,7 +74,7 @@ export default function MyPageForm({
         image: formData.image,
       })
     );
-    setIsValidated(!validateName(formData.nickname.trim()));
+    setIsValidated(!validateNickname(formData.nickname.trim()));
   }, [user, formData.nickname, formData.image]);
 
   return (
@@ -101,7 +101,7 @@ export default function MyPageForm({
           placeholder="이름을 입력해주세요."
           value={formData.nickname}
           onChange={handleChange}
-          validator={validateName}
+          validator={validateNickname}
           state={isEditing ? undefined : 'default-disabled'}
         />
       </div>

--- a/app/mypage/MyPageForm.tsx
+++ b/app/mypage/MyPageForm.tsx
@@ -1,31 +1,32 @@
 'use client';
 
 import React, { useCallback, useEffect, useState } from 'react';
+
+import type { UserFormDataTypes } from '@app/mypage/page';
+import type { UserType } from '@app/types/shared';
 import InputField from '@components/InputField';
 import Button from '@components/Button';
 import ImageUpload from '@components/ImageUpload';
 import { validateName, validateUserUpdated } from '@app/utils/formValidators';
-import type { UserFormDataTypes } from '@app/mypage/page';
-import type { UserType } from '@app/types/shared';
 
 export interface MyPageFormProps {
+  initialFormData: UserFormDataTypes;
   isEditing: boolean;
   onSubmit: (formData: UserFormDataTypes) => void;
   user: UserType | null;
 }
 
 export default function MyPageForm({
+  initialFormData,
   isEditing,
   onSubmit,
   user,
 }: MyPageFormProps) {
-  const [formData, setFormData] = useState<UserFormDataTypes>({
-    nickname: user?.nickname || '',
-    email: user?.email || '',
-    image: user?.image || '',
-  });
   const [isValidated, setIsValidated] = useState(false);
   const [isChanged, setIsChanged] = useState(false);
+
+  const [formData, setFormData] = useState(initialFormData);
+
   const validateForm = useCallback(() => {
     const trimmedName = formData.nickname.trim();
     const error = validateName(trimmedName);
@@ -56,13 +57,16 @@ export default function MyPageForm({
   };
 
   useEffect(() => {
-    if (!user) return;
+    if (user) {
+      setFormData({
+        nickname: user.nickname,
+        image: user.image || '',
+      });
+    }
+  }, [user]);
 
-    setFormData({
-      nickname: formData.nickname,
-      email: formData.email,
-      image: formData.image || '',
-    });
+  useEffect(() => {
+    if (!user) return;
 
     setIsChanged(
       validateUserUpdated(user, {
@@ -71,7 +75,7 @@ export default function MyPageForm({
       })
     );
     setIsValidated(!validateName(formData.nickname.trim()));
-  }, [user, formData.nickname, formData.image, formData.email]);
+  }, [user, formData.nickname, formData.image]);
 
   return (
     <form
@@ -103,29 +107,37 @@ export default function MyPageForm({
       </div>
 
       <div className="space-y-3">
-        <label htmlFor="email">이메일</label>
+        <div className="flex items-center space-x-4">
+          <label htmlFor="email">이메일</label>
+          {isEditing && (
+            <p className="text-xs text-t-default">
+              이메일은 변경할 수 없습니다.
+            </p>
+          )}
+        </div>
         <InputField
           id="email"
           type="email"
-          placeholder="이메일은 변경할 수 없습니다."
-          value={formData.email}
+          placeholder={user?.email || ''}
           onChange={handleChange}
           state="default-disabled"
         />
       </div>
 
-      {isEditing && (
-        <div className="overflow-hidden transition-all duration-300">
-          <Button
-            type="submit"
-            size="large"
-            classname="w-full"
-            disabled={!isValidated || !isChanged}
-          >
-            변경 사항 저장
-          </Button>
-        </div>
-      )}
+      <div
+        className={`overflow-hidden transition-all duration-300 ${
+          isEditing ? 'max-h-20 opacity-100' : 'max-h-0 opacity-0'
+        }`}
+      >
+        <Button
+          type="submit"
+          size="large"
+          classname="w-full"
+          disabled={!isValidated || !isChanged}
+        >
+          변경 사항 저장
+        </Button>
+      </div>
     </form>
   );
 }

--- a/app/mypage/MyPageForm.tsx
+++ b/app/mypage/MyPageForm.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import InputField from '@components/InputField';
+import Button from '@components/Button';
+import ImageUpload from '@components/ImageUpload';
+import { validateName, validateUserUpdated } from '@app/utils/formValidators';
+import type { UserFormDataTypes } from '@app/mypage/page';
+import type { UserType } from '@app/types/shared';
+
+export interface MyPageFormProps {
+  isEditing: boolean;
+  onSubmit: (formData: UserFormDataTypes) => void;
+  user: UserType | null;
+}
+
+export default function MyPageForm({
+  isEditing,
+  onSubmit,
+  user,
+}: MyPageFormProps) {
+  const [formData, setFormData] = useState<UserFormDataTypes>({
+    nickname: user?.nickname || '',
+    email: user?.email || '',
+    image: user?.image || '',
+  });
+  const [isValidated, setIsValidated] = useState(false);
+  const [isChanged, setIsChanged] = useState(false);
+  const validateForm = useCallback(() => {
+    const trimmedName = formData.nickname.trim();
+    const error = validateName(trimmedName);
+    setIsValidated(!error);
+  }, [formData.nickname]);
+
+  useEffect(() => {
+    validateForm();
+  }, [validateForm]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const handleUploadSuccess = (url: string) => {
+    setFormData((prev) => ({ ...prev, image: url }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (isValidated) {
+      onSubmit(formData);
+    }
+  };
+
+  useEffect(() => {
+    if (!user) return;
+
+    setFormData({
+      nickname: formData.nickname,
+      email: formData.email,
+      image: formData.image || '',
+    });
+
+    setIsChanged(
+      validateUserUpdated(user, {
+        nickname: formData.nickname,
+        image: formData.image,
+      })
+    );
+    setIsValidated(!validateName(formData.nickname.trim()));
+  }, [user, formData.nickname, formData.image, formData.email]);
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-8"
+    >
+      <div className="flex flex-col items-start justify-start space-y-3">
+        <label htmlFor="image">프로필 이미지</label>
+        <ImageUpload
+          url={formData.image}
+          onUploadSuccess={handleUploadSuccess}
+          onUploadError={() => {}}
+          variant="circle"
+          disabled={!isEditing}
+        />
+      </div>
+
+      <div className="space-y-3">
+        <label htmlFor="nickname">이름</label>
+        <InputField
+          id="nickname"
+          type="text"
+          placeholder="이름을 입력해주세요."
+          value={formData.nickname}
+          onChange={handleChange}
+          validator={validateName}
+          state={isEditing ? undefined : 'default-disabled'}
+        />
+      </div>
+
+      <div className="space-y-3">
+        <label htmlFor="email">이메일</label>
+        <InputField
+          id="email"
+          type="email"
+          placeholder="이메일은 변경할 수 없습니다."
+          value={formData.email}
+          onChange={handleChange}
+          state="default-disabled"
+        />
+      </div>
+
+      {isEditing && (
+        <div className="overflow-hidden transition-all duration-300">
+          <Button
+            type="submit"
+            size="large"
+            classname="w-full"
+            disabled={!isValidated || !isChanged}
+          >
+            변경 사항 저장
+          </Button>
+        </div>
+      )}
+    </form>
+  );
+}

--- a/app/mypage/UpdatePasswordModal.tsx
+++ b/app/mypage/UpdatePasswordModal.tsx
@@ -1,14 +1,15 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import InputField from '../components/InputField';
-import Modal, { ModalFooter } from '../components/Modal';
+
 import {
   validateConfirmPassword,
   validatePassword,
-} from '../utils/formValidators';
-import Button from '../components/Button';
-import { PasswordFormDataTypes } from './page';
+} from '@utils/formValidators';
+import InputField from '@components/InputField';
+import Modal, { ModalFooter } from '@components/Modal';
+import Button from '@components/Button';
+import { PasswordFormDataTypes } from '@app/mypage/page';
 
 interface UpdatePasswordModalProps {
   isOpen: boolean;
@@ -38,7 +39,6 @@ export default function UpdatePasswordModal({
         validateConfirmPassword(passwordFormData.confirmPassword.trim()) || '',
     };
 
-    // 에러가 하나라도 있으면 false 반환
     setIsValidated(!Object.values(newErrors).some((error) => error));
   }, [passwordFormData]);
 

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 
@@ -79,15 +79,6 @@ export default function MyPage() {
     },
     onError: createErrorHandler({ prefixMessage: '회원 탈퇴 실패' }),
   });
-
-  useEffect(() => {
-    const { accessToken } = useUserStore.getState();
-
-    if (!accessToken) {
-      toast.error('로그인이 필요합니다!');
-      router.push('/');
-    }
-  }, [router]);
 
   const handleUpdateUserInfo = (formData: UserFormDataTypes) => {
     const updatedParams: Partial<UserFormDataTypes> = {

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 
 import { useMutation } from '@tanstack/react-query';
+import { toast } from 'react-toastify';
 
 import {
   deleteUser,
@@ -19,7 +20,6 @@ import Button from '@components/Button';
 import UpdatePasswordModal from '@app/mypage/UpdatePasswordModal';
 import ConFirmSecessionModal from '@app/mypage/ConfirnSecessionModal';
 import MyPageForm from '@app/mypage/MyPageForm';
-import { toast } from 'react-toastify';
 
 export interface PasswordFormDataTypes {
   password: string;

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -32,7 +32,8 @@ export interface UserFormDataTypes {
 }
 
 export default function MyPage() {
-  const { user, updateUser, clearUser } = useUserStore();
+  const { user, isKakaoLogin, isGoogleLogin, updateUser, clearUser } =
+    useUserStore();
   const { clearTeam } = useTeamStore();
   const [isEditing, setIsEditing] = useState(false);
   const [isPasswordUpdateModalOpen, setPasswordUpdateModalOpen] =
@@ -145,19 +146,21 @@ export default function MyPage() {
         />
       </div>
 
-      <div className="flex h-10 items-center justify-between border-t-[1px] border-gray-500 pb-4 pt-10">
-        <p>비밀번호 변경</p>
-        <Button
-          type="button"
-          size="X-small"
-          onClick={() => setPasswordUpdateModalOpen(true)}
-          state="default"
-          classname="text-xs"
-          disabled={isEditing}
-        >
-          변경하기
-        </Button>
-      </div>
+      {!(isKakaoLogin || isGoogleLogin) && (
+        <div className="flex h-10 items-center justify-between border-t-[1px] border-gray-500 pb-4 pt-10">
+          <p>비밀번호 변경</p>
+          <Button
+            type="button"
+            size="X-small"
+            onClick={() => setPasswordUpdateModalOpen(true)}
+            state="default"
+            classname="text-xs"
+            disabled={isEditing}
+          >
+            변경하기
+          </Button>
+        </div>
+      )}
 
       <button
         className="flex items-center gap-2 hover:opacity-70"

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -19,6 +19,7 @@ import Button from '@components/Button';
 import UpdatePasswordModal from '@app/mypage/UpdatePasswordModal';
 import ConFirmSecessionModal from '@app/mypage/ConfirnSecessionModal';
 import MyPageForm from '@app/mypage/MyPageForm';
+import { toast } from 'react-toastify';
 
 export interface PasswordFormDataTypes {
   password: string;
@@ -27,12 +28,11 @@ export interface PasswordFormDataTypes {
 
 export interface UserFormDataTypes {
   nickname: string;
-  email?: string;
   image: string;
 }
 
 export default function MyPage() {
-  const { user, accessToken, updateUser, clearUser } = useUserStore();
+  const { user, updateUser, clearUser } = useUserStore();
   const { clearTeam } = useTeamStore();
   const [isEditing, setIsEditing] = useState(false);
   const [isPasswordUpdateModalOpen, setPasswordUpdateModalOpen] =
@@ -41,13 +41,18 @@ export default function MyPage() {
 
   const router = useRouter();
 
+  const initialFormData = {
+    nickname: user?.nickname || '',
+    image: user?.image || '',
+  };
+
   const updateUserMuation = useMutation({
     mutationFn: patchUser,
     onSuccess: async () => {
       const { nickname, image } = await getUser();
 
       updateUser({ nickname, image });
-      alert('계정 정보가 변경되었습니다.');
+      toast.success('계정 정보가 변경되었습니다.');
       setIsEditing(false);
     },
     onError: createErrorHandler({ prefixMessage: '계정 정보 변경 실패' }),
@@ -56,7 +61,7 @@ export default function MyPage() {
   const updatePasswordMutation = useMutation({
     mutationFn: patchUserPassword,
     onSuccess: () => {
-      alert('비밀번호가 변경되었습니다.');
+      toast.success('비밀번호가 변경되었습니다.');
     },
     onError: createErrorHandler({ prefixMessage: '비밀번호 변경 실패' }),
   });
@@ -67,7 +72,7 @@ export default function MyPage() {
       clearUser();
       clearTeam();
 
-      alert('회원 탈퇴가 정상 처리되었습니다.');
+      toast('회원 탈퇴가 정상 처리되었습니다.');
 
       router.push('/');
     },
@@ -75,13 +80,13 @@ export default function MyPage() {
   });
 
   useEffect(() => {
-    const { accessToken: isAthenticated } = useUserStore.getState();
+    const { accessToken } = useUserStore.getState();
 
-    if (!isAthenticated) {
-      alert('로그인이 필요합니다!');
+    if (!accessToken) {
+      toast.error('로그인이 필요합니다!');
       router.push('/');
     }
-  }, [accessToken, router]);
+  }, [router]);
 
   const handleUpdateUserInfo = (formData: UserFormDataTypes) => {
     const updatedParams: Partial<UserFormDataTypes> = {
@@ -133,6 +138,7 @@ export default function MyPage() {
         </div>
         <div className="border-t-[1px] border-gray-500 pb-2" />
         <MyPageForm
+          initialFormData={initialFormData}
           isEditing={isEditing}
           onSubmit={handleUpdateUserInfo}
           user={user}
@@ -147,13 +153,14 @@ export default function MyPage() {
           onClick={() => setPasswordUpdateModalOpen(true)}
           state="default"
           classname="text-xs"
+          disabled={isEditing}
         >
           변경하기
         </Button>
       </div>
 
       <button
-        className="flex items-center gap-2"
+        className="flex items-center gap-2 hover:opacity-70"
         onClick={() => setIsSecessionModalOpen(true)}
       >
         <Image

--- a/app/oauth/google/page.tsx
+++ b/app/oauth/google/page.tsx
@@ -26,11 +26,11 @@ const GoogleCallback = () => {
 
       if (data.user?.nickname && /^\d+$/.test(data.user.nickname)) {
         toast.warn(
-          '닉네임 중복으로 임시 닉네임이 부여되었습니다. 계정 설정에서 닉네임을 변경해주세요!'
+          `'${session?.user.name}'은 사용중인 닉네임 입니다. 계정 설정에서 닉네임을 변경해주세요!`
         );
       }
     },
-    [easySignInMutation]
+    [easySignInMutation, session?.user.name]
   );
 
   useEffect(() => {

--- a/app/oauth/google/page.tsx
+++ b/app/oauth/google/page.tsx
@@ -8,16 +8,14 @@ import { toast } from 'react-toastify';
 
 import EasyLoginLoadingPage from '@app/oauth/EasyLoginLoadingPage';
 import { useEasySignIn } from '@hooks/useEasySignIn';
-import useUserStore from '@app/stores/userStore';
 
 const GoogleCallback = () => {
-  const { setIsGoogleLogin } = useUserStore();
   const [isProcessing, setIsProcessing] = useState(false);
 
   const { data: session, status } = useSession();
   const router = useRouter();
 
-  const easySignInMutation = useEasySignIn();
+  const easySignInMutation = useEasySignIn({ provider: 'GOOGLE' });
 
   const handleGoogleLogin = useCallback(
     async (token: string) => {
@@ -57,16 +55,8 @@ const GoogleCallback = () => {
       }
 
       handleGoogleLogin(jwtToken);
-      setIsGoogleLogin(true);
     }
-  }, [
-    status,
-    session,
-    isProcessing,
-    handleGoogleLogin,
-    setIsGoogleLogin,
-    router,
-  ]);
+  }, [status, session, isProcessing, handleGoogleLogin, router]);
 
   return <EasyLoginLoadingPage type="google" />;
 };

--- a/app/oauth/google/page.tsx
+++ b/app/oauth/google/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 import { useSession } from 'next-auth/react';
 import { toast } from 'react-toastify';
@@ -8,7 +9,6 @@ import { toast } from 'react-toastify';
 import EasyLoginLoadingPage from '@app/oauth/EasyLoginLoadingPage';
 import { useEasySignIn } from '@hooks/useEasySignIn';
 import useUserStore from '@app/stores/userStore';
-import { useRouter } from 'next/navigation';
 
 const GoogleCallback = () => {
   const { setIsGoogleLogin } = useUserStore();
@@ -20,11 +20,17 @@ const GoogleCallback = () => {
   const easySignInMutation = useEasySignIn();
 
   const handleGoogleLogin = useCallback(
-    (token: string) => {
-      easySignInMutation.mutate({
+    async (token: string) => {
+      const data = await easySignInMutation.mutateAsync({
         token,
         provider: 'GOOGLE',
       });
+
+      if (data.user?.nickname && /^\d+$/.test(data.user.nickname)) {
+        toast.warn(
+          '닉네임 중복으로 임시 닉네임이 부여되었습니다. 계정 설정에서 닉네임을 변경해주세요!'
+        );
+      }
     },
     [easySignInMutation]
   );
@@ -52,7 +58,6 @@ const GoogleCallback = () => {
 
       handleGoogleLogin(jwtToken);
       setIsGoogleLogin(true);
-    } else {
     }
   }, [
     status,

--- a/app/oauth/kakao/page.tsx
+++ b/app/oauth/kakao/page.tsx
@@ -10,7 +10,8 @@ import { useRouter } from 'next/navigation';
 
 const KakaoCallback = () => {
   const [isProcessing, setIsProcessing] = useState(false);
-  const easySignInMutation = useEasySignIn();
+
+  const easySignInMutation = useEasySignIn({ provider: 'KAKAO' });
 
   const router = useRouter();
   const hasShownError = useRef(false);

--- a/app/oauth/kakao/page.tsx
+++ b/app/oauth/kakao/page.tsx
@@ -16,14 +16,21 @@ const KakaoCallback = () => {
   const hasShownError = useRef(false);
 
   const handleKakaoLogin = useCallback(
-    (code: string, receivedState: string) => {
+    async (code: string, receivedState: string) => {
       setIsProcessing(true);
-      easySignInMutation.mutate({
+
+      const data = await easySignInMutation.mutateAsync({
         token: code,
         provider: 'KAKAO',
         state: receivedState,
         redirectUri: process.env.NEXT_PUBLIC_KAKAO_LOGIN_REDIRECT_URI,
       });
+
+      if (data.user?.nickname && /^\d+$/.test(data.user.nickname)) {
+        toast.warn(
+          '카카오 임시 닉네임을 사용중입니다. 계정 설정에서 닉네임을 변경해주세요!'
+        );
+      }
     },
     [easySignInMutation]
   );

--- a/app/signup/SignupForm.tsx
+++ b/app/signup/SignupForm.tsx
@@ -66,11 +66,11 @@ export default function SignupForm({
     >
       <div className="space-y-6">
         <div className="space-y-3">
-          <label htmlFor="nickname">이름</label>
+          <label htmlFor="nickname">닉네임</label>
           <InputField
             id="nickname"
             type="text"
-            placeholder="이름을 입력해주세요."
+            placeholder="닉네임을 입력해주세요."
             value={formData.nickname}
             onChange={handleChange}
             validator={validateName}

--- a/app/signup/SignupForm.tsx
+++ b/app/signup/SignupForm.tsx
@@ -9,7 +9,7 @@ import Button from '@components/Button';
 import {
   validateConfirmPassword,
   validateEmail,
-  validateName,
+  validateNickname,
   validatePassword,
 } from '@utils/formValidators';
 
@@ -32,7 +32,7 @@ export default function SignupForm({
 
   const validateForm = useCallback(() => {
     const newErrors = {
-      nickname: validateName(formData.nickname.trim()) || '',
+      nickname: validateNickname(formData.nickname.trim()) || '',
       email: validateEmail(formData.email.trim()) || '',
       password: validatePassword(formData.password.trim()) || '',
       confirmPassword:
@@ -73,7 +73,7 @@ export default function SignupForm({
             placeholder="닉네임을 입력해주세요."
             value={formData.nickname}
             onChange={handleChange}
-            validator={validateName}
+            validator={validateNickname}
           />
         </div>
         <div className="space-y-3">

--- a/app/utils/formValidators.ts
+++ b/app/utils/formValidators.ts
@@ -1,10 +1,11 @@
 import { UserFormDataTypes } from '../mypage/page';
 import { UserType } from '../types/shared';
 
-export const validateName = (value: string) => {
+export const validateNickname = (value: string) => {
   if (!value.trim()) return '닉네임은 필수 입력입니다.';
   if (value.length < 2) return '이름은 최소 2자 이상이어야 합니다.';
   if (20 <= value.length) return '닉네임은 최대 20자까지 가능합니다.';
+  if (/^\d+$/.test(value)) return '닉네임은 숫자로만 구성될 수 없습니다.';
   return undefined;
 };
 


### PR DESCRIPTION
## 📌 Related Issue
- Closed #151

## 🧾 작업 사항
- 계정 설정 페이지 리팩토링
  - 컨벤션 반영
  - `MyPageForm.tsx`컴포넌트 분리
- 구글 로그인 시 닉네임 변경 권유 토스트 추가
  - 구글 프로필 닉네임과 중복된 닉네임이 있는 경우, 랜덤한 수열로 닉네임이 생성됨
- 카카오 로그인 시 닉네임 변경 권유 토스트 추가
  - 카카오는 기본적으로 숫자 닉네임 생성. 닉네임이 숫자로 이루어져 있다면 안내 토스트 팝업
  - 위 두 사항에 맞추어 닉네임 검증 함수에 숫자로만 이루어진 경우를 추가
- 간편 로그인 시 비밀번호 변경 폼 숨김
- 계정 설정 페이지 로그인 검증 제거

## 📚 리뷰 포인트
- 계정 설정 페이지 `page.tsx`의 볼륨이 너무 컸기에, 입력 폼을 컴포넌트로 분리했습니다.
- 간편 로그인 시 닉네임 처리에 대한 토스트를 추가했습니다.
- 바로 계정 설정 페이지로 리디렉션 하는 기능을 당장은 추가하지 않기로 했는데, 보시다가 필요성이 느껴지시면 다시 알려주세요!
- 로그인 검증을 제거했는데, 공통 로그인 검증을 미들웨어 사용해서 한 번 구현해보겠습니다.

## 📷 Screenshot/GIF
- 카카오 로그인
![image](https://github.com/user-attachments/assets/9f5f6151-a5dd-46f4-afd4-0d0bd41f2009)

- 구글 로그인
![image](https://github.com/user-attachments/assets/851b69ca-c290-4426-9d16-5f0ed909ad4a)

- 간편 로그인 시 비밀번호 변경 숨김
![image](https://github.com/user-attachments/assets/d80f9b26-7c3c-4897-80f1-d1961006214b)
