### PR TITLE
feat/#154 범용 알림 모달

### DIFF
--- a/app/components/Modal/AlertModal.tsx
+++ b/app/components/Modal/AlertModal.tsx
@@ -4,17 +4,20 @@ import Modal, { type ModalProps, ModalFooter } from './index';
 import Button from '@components/Button';
 
 export interface AlertModalProps extends ModalProps {
+  buttonText: string;
   onOkClick: () => void;
 }
 
 interface AlertModalConfig {
   title?: string;
+  buttonText?: string;
   onOkClick?: () => void;
 }
 
 const initProps = {
   isOpen: false,
   title: '알림',
+  buttonText: '확인',
   children: 'message',
   onClose: () => {},
   onOkClick: () => {},
@@ -23,6 +26,7 @@ const initProps = {
 const AlertModal = ({
   isOpen,
   title,
+  buttonText,
   onOkClick,
   children,
 }: AlertModalProps) => {
@@ -35,7 +39,7 @@ const AlertModal = ({
     >
       <p className="text-center">{children}</p>
       <ModalFooter>
-        <Button onClick={() => onOkClick()}>확인</Button>
+        <Button onClick={() => onOkClick()}>{buttonText}</Button>
       </ModalFooter>
     </Modal>
   );
@@ -50,11 +54,16 @@ const useAlertModal = () => {
 
   const alertModalOpen = (
     message: string,
-    { title = config.title, onOkClick }: AlertModalConfig
+    {
+      title = config.title,
+      buttonText = config.buttonText,
+      onOkClick,
+    }: AlertModalConfig
   ) => {
     setConfig({
       isOpen: true,
       title,
+      buttonText,
       children: message,
       onClose,
       onOkClick: () => {

--- a/app/components/Modal/AlertModal.tsx
+++ b/app/components/Modal/AlertModal.tsx
@@ -68,7 +68,7 @@ const useAlertModal = () => {
     return <AlertModal {...config} />;
   };
 
-  return { AlertModalContainer, alertModalOpen };
+  return { AlertModalContainer, config, alertModalOpen };
 };
 
 export default AlertModal;

--- a/app/components/Modal/AlertModal.tsx
+++ b/app/components/Modal/AlertModal.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+
+import Modal, { type ModalProps, ModalFooter } from './index';
+import Button from '@components/Button';
+
+export interface AlertModalProps extends ModalProps {
+  onOkClick: () => void;
+}
+
+interface AlertModalConfig {
+  title?: string;
+  onOkClick?: () => void;
+}
+
+const initProps = {
+  isOpen: false,
+  title: '알림',
+  children: 'message',
+  onClose: () => {},
+  onOkClick: () => {},
+};
+
+const AlertModal = ({
+  isOpen,
+  title,
+  onOkClick,
+  children,
+}: AlertModalProps) => {
+  return (
+    <Modal
+      isOpen={isOpen}
+      title={title}
+      hasCloseButton={false}
+      onClose={() => null}
+    >
+      <p className="text-center">{children}</p>
+      <ModalFooter>
+        <Button onClick={() => onOkClick()}>확인</Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+const useAlertModal = () => {
+  const [config, setConfig] = useState<AlertModalProps>(initProps);
+
+  const onClose = () => {
+    setConfig({ ...config, isOpen: false });
+  };
+
+  const alertModalOpen = (
+    message: string,
+    { title = config.title, onOkClick }: AlertModalConfig
+  ) => {
+    setConfig({
+      isOpen: true,
+      title,
+      children: message,
+      onClose,
+      onOkClick: () => {
+        if (onOkClick) onOkClick();
+        onClose();
+      },
+    });
+  };
+
+  const AlertModalContainer = () => {
+    return <AlertModal {...config} />;
+  };
+
+  return { AlertModalContainer, alertModalOpen };
+};
+
+export default AlertModal;
+export { useAlertModal };

--- a/app/components/Modal/index.tsx
+++ b/app/components/Modal/index.tsx
@@ -82,4 +82,4 @@ export default function Modal({
   );
 }
 
-export { ModalFooter };
+export { type ModalProps, ModalFooter };

--- a/app/dummy/modal/page.tsx
+++ b/app/dummy/modal/page.tsx
@@ -14,7 +14,8 @@ export default function Home() {
   const handleClick = () => {
     alertModalOpen('테스트 알림 모달 입니다.', {
       title: '알림',
-      onOkClick: () => console.log('확인을 눌렀어요.'),
+      buttonText: 'OK',
+      onOkClick: () => console.log('OK 눌렀어요.'),
     });
   };
 

--- a/app/dummy/modal/page.tsx
+++ b/app/dummy/modal/page.tsx
@@ -2,11 +2,21 @@
 
 import { useState } from 'react';
 import Modal, { ModalFooter } from '../../components/Modal';
+import { useAlertModal } from '@components/Modal/AlertModal';
 
 export default function Home() {
   const [modalOpen, setModalOpen] = useState(false);
   const [dangerModalOpen, setDangerModalOpen] = useState(false);
   const [bigModalOpen, setBigModalOpen] = useState(false);
+
+  const { AlertModalContainer, alertModalOpen } = useAlertModal();
+
+  const handleClick = () => {
+    alertModalOpen('테스트 알림 모달 입니다.', {
+      title: '알림',
+      onOkClick: () => console.log('확인을 눌렀어요.'),
+    });
+  };
 
   return (
     <>
@@ -35,6 +45,14 @@ export default function Home() {
           onClick={() => setBigModalOpen(true)}
         >
           큰 모달 열기
+        </button>
+
+        <button
+          type="button"
+          className="rounded-xl bg-primary px-4 py-[14px] text-lg font-semibold text-t-inverse"
+          onClick={handleClick}
+        >
+          alert modal open
         </button>
       </div>
 
@@ -96,6 +114,8 @@ export default function Home() {
           </button>
         </ModalFooter>
       </Modal>
+
+      <AlertModalContainer />
     </>
   );
 }


### PR DESCRIPTION
## 📌 Related Issue
- Closed #154 

## 🧾 작업 사항
- AlertModal 을 추가

## 📚 리뷰 포인트
- 토스트 처럼 만들고 싶었으나 실패함
- 사용할 곳에서 모달 불러서 사용해야 함
```tsx
const { AlertModalContainer, alertModalOpen } = useAlertModal();

return (
  <>
    <button onClick={() => alertModalOpen('여기에 메시지')}>click</button>
    <AlertModalContainer />
  </>
);
```
- 이게 제일 심플한 사용 방법인데, 속성 몇개 더 있음.
```ts
const handleClick = () => {
    alertModalOpen('테스트 알림 모달 입니다.', {
      title: '알림',
      buttonText: 'OK',
      onOkClick: () => console.log('OK 눌렀어요.'),
    });
  };
```
- 토스트 비슷하게 만들어 봤는데, 쓸 일이 있을지는 모르겠음.
- 그냥 `AlertModal` 불러서 사용할 수도 있긴 함.
- 훅 부분만 따로 빼면 사용방법이 더 복잡해져서 우선 빼지는 않음.
- 속성에 `buttonText` 추가함

## 📷 Screenshot/GIF
![image](https://github.com/user-attachments/assets/7d55638d-5a2b-490c-839b-8dd9045b848c)
