### PR TITLE
Feat/157  middleward 추가

### DIFF
--- a/app/[teamid]/page.tsx
+++ b/app/[teamid]/page.tsx
@@ -39,6 +39,8 @@ export default function TeamPage() {
   });
 
   useEffect(() => {
+    if (!user) return;
+
     if (group) {
       // 사용자 검증 및 역할 받아 설정
       const member = group.members.find((member) => member.userId === user?.id);

--- a/app/boards/write/page.tsx
+++ b/app/boards/write/page.tsx
@@ -49,13 +49,6 @@ const WriteContent = () => {
     }
   }, [user]);
 
-  useEffect(() => {
-    if (!isLoading && user === null) {
-      toast.error('로그인이 필요합니다.');
-      router.replace('/login');
-    }
-  }, [isLoading, user, router]);
-
   //수정하기로 들어갔을 때 게시글 정보 가져옴
   useEffect(() => {
     if (!articleId) return;

--- a/app/components/Gnb/ProfileDropDown.tsx
+++ b/app/components/Gnb/ProfileDropDown.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 
 import { signOut } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
 
 import useUserStore from '@stores/userStore';
 import useTeamStore from '@stores/teamStore';
@@ -15,21 +16,24 @@ interface ProfileDropDownProps {
 }
 
 const dropDownItemStyle = 'px-0 py-0 text-md sm:text-lg';
-const linkStyle = 'block px-3 py-2 sm:py-3';
+const itemStyle = 'block px-3 py-2 sm:py-3';
 
 export default function ProfileDropDown({ user }: ProfileDropDownProps) {
   const { isGoogleLogin, clearUser } = useUserStore();
   const { clearTeam } = useTeamStore();
 
+  const router = useRouter();
+
   const handleLogout = () => {
     clearUser();
     clearTeam();
+    document.cookie = 'accessToken=; path=/; max-age=0';
 
     if (isGoogleLogin) {
       signOut();
-
-      return;
     }
+
+    router.push('/');
   };
 
   return (
@@ -57,7 +61,7 @@ export default function ProfileDropDown({ user }: ProfileDropDownProps) {
         <Dropdown.MenuItem className={dropDownItemStyle}>
           <Link
             href="/myhistory"
-            className={linkStyle}
+            className={itemStyle}
           >
             마이 히스토리
           </Link>
@@ -66,7 +70,7 @@ export default function ProfileDropDown({ user }: ProfileDropDownProps) {
         <Dropdown.MenuItem className={dropDownItemStyle}>
           <Link
             href="/mypage"
-            className={linkStyle}
+            className={itemStyle}
           >
             계정 설정
           </Link>
@@ -75,22 +79,19 @@ export default function ProfileDropDown({ user }: ProfileDropDownProps) {
         <Dropdown.MenuItem className={dropDownItemStyle}>
           <Link
             href="/invitation"
-            className={linkStyle}
+            className={itemStyle}
           >
             팀 참여
           </Link>
         </Dropdown.MenuItem>
 
-        <Dropdown.MenuItem
-          className={dropDownItemStyle}
-          onClick={handleLogout}
-        >
-          <Link
-            href="/"
-            className={linkStyle}
+        <Dropdown.MenuItem className={dropDownItemStyle}>
+          <div
+            className={itemStyle}
+            onClick={handleLogout}
           >
             로그아웃
-          </Link>
+          </div>
         </Dropdown.MenuItem>
       </Dropdown.Menu>
     </Dropdown>

--- a/app/hooks/useEasySignIn.ts
+++ b/app/hooks/useEasySignIn.ts
@@ -33,6 +33,7 @@ export const useEasySignIn = ({ provider }: { provider: ProviderType }) => {
       setAccessToken(accessToken);
       setRefreshToken(refreshToken);
       setUser(user);
+      document.cookie = `accessToken=${accessToken}; path=/; max-age=${60 * 60 * 24}`;
 
       if (provider === 'GOOGLE') {
         setIsGoogleLogin(true);

--- a/app/login/layout.tsx
+++ b/app/login/layout.tsx
@@ -1,0 +1,11 @@
+'use client';
+import { Suspense } from 'react';
+import Loading from '@components/Loading';
+
+export default function LoginLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <Suspense fallback={<Loading />}>{children}</Suspense>;
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,36 +1,48 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 import { useMutation } from '@tanstack/react-query';
 
-import type { AuthResponseType, LoginFormDataType } from '@app/types/auth';
-import LoginForm from '@app/login/LoginForm';
+import type { LoginFormDataType } from '@app/types/auth';
 import { postAuthSignIn } from '@api/auth.api';
-import useUserStore from '@stores/userStore';
-import EasyLogin from '@app/login/EasyLogin';
 import { createErrorHandler } from '@utils/createErrorHandler';
+import Modal, { ModalFooter } from '@components/Modal';
+import Button from '@components/Button';
+import useUserStore from '@stores/userStore';
+import LoginForm from '@app/login/LoginForm';
+import EasyLogin from '@app/login/EasyLogin';
 
 export default function LoginPage() {
-  const { user, setAccessToken, setRefreshToken, setUser } = useUserStore();
+  const { setAccessToken, setRefreshToken, setUser } = useUserStore();
+
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const stateParam = searchParams.get('state');
+  const redirectParam = searchParams.get('redirect');
+
+  const [showModal, setShowModal] = useState(false);
+  const [modalDismissed, setModalDismissed] = useState(false);
 
   useEffect(() => {
-    if (user?.id) {
-      router.push('/');
+    if (stateParam === 'login-required') {
+      setShowModal(true);
+    } else {
+      setModalDismissed(true);
     }
-  }, [user, router]);
+  }, [stateParam]);
 
   const loginMutation = useMutation({
     mutationFn: postAuthSignIn,
-    onSuccess: (data: AuthResponseType['postAuthSignIn']) => {
+    onSuccess: (data) => {
       const { user, accessToken, refreshToken } = data;
       setAccessToken(accessToken);
       setRefreshToken(refreshToken);
       setUser(user);
-      router.push('/');
+      document.cookie = `accessToken=${accessToken}; path=/; max-age=${60 * 60 * 24}`;
+      router.push(redirectParam || '/');
     },
     onError: createErrorHandler({ prefixMessage: '로그인 실패' }),
   });
@@ -39,31 +51,63 @@ export default function LoginPage() {
     loginMutation.mutate(formData);
   };
 
+  // 모달 확인 버튼 클릭 시 호출할 함수
+  const handleModalConfirm = () => {
+    setShowModal(false);
+    setModalDismissed(true);
+    setShowModal(false);
+  };
+
   return (
     <div className="flex min-h-screen flex-col items-center bg-b-primary px-4 pt-[10vh] sm:pt-[15vh]">
-      <h2 className="text-center text-2xl font-medium lg:text-4xl">로그인</h2>
-      <div className="w-full max-w-[460px] space-y-12 pt-[4vh] sm:pt-[6vh]">
-        <div className="flex flex-col gap-6">
-          <LoginForm onSubmit={handleLoginSubmit} />
-          <div className="text-center font-medium">
-            아직 계정이 없으신가요?
-            <Link
-              href="/signup"
-              className="ml-2 text-primary underline hover:opacity-50"
+      {showModal && (
+        <Modal
+          isOpen={showModal}
+          onClose={() => setShowModal(false)}
+          hasCloseButton={false}
+          icon="danger"
+          title="로그인이 필요한 페이지입니다."
+        >
+          <p className="text-center"></p>
+          <ModalFooter>
+            <Button
+              state="danger"
+              onClick={handleModalConfirm}
             >
-              가입하기
-            </Link>
+              확인
+            </Button>
+          </ModalFooter>
+        </Modal>
+      )}
+      {modalDismissed && (
+        <>
+          <h2 className="text-center text-2xl font-medium lg:text-4xl">
+            로그인
+          </h2>
+          <div className="w-full max-w-[460px] space-y-12 pt-[4vh] sm:pt-[6vh]">
+            <div className="flex flex-col gap-6">
+              <LoginForm onSubmit={handleLoginSubmit} />
+              <div className="text-center font-medium">
+                아직 계정이 없으신가요?
+                <Link
+                  href="/signup"
+                  className="ml-2 text-primary underline hover:opacity-50"
+                >
+                  가입하기
+                </Link>
+              </div>
+            </div>
+            <div className="space-y-4">
+              <div className="flex w-full items-center gap-4">
+                <div className="flex-1 border-t border-bd-primary opacity-10"></div>
+                <span>OR</span>
+                <div className="flex-1 border-t border-bd-primary opacity-10"></div>
+              </div>
+              <EasyLogin page="login" />
+            </div>
           </div>
-        </div>
-        <div className="space-y-4">
-          <div className="flex w-full items-center gap-4">
-            <div className="flex-1 border-t border-bd-primary opacity-10"></div>
-            <span>OR</span>
-            <div className="flex-1 border-t border-bd-primary opacity-10"></div>
-          </div>
-          <EasyLogin page="login" />
-        </div>
-      </div>
+        </>
+      )}
     </div>
   );
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { Suspense, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 
@@ -14,6 +14,7 @@ import Button from '@components/Button';
 import useUserStore from '@stores/userStore';
 import LoginForm from '@app/login/LoginForm';
 import EasyLogin from '@app/login/EasyLogin';
+import Loading from '@components/Loading';
 
 export default function LoginPage() {
   const { setAccessToken, setRefreshToken, setUser } = useUserStore();
@@ -51,63 +52,63 @@ export default function LoginPage() {
     loginMutation.mutate(formData);
   };
 
-  // 모달 확인 버튼 클릭 시 호출할 함수
   const handleModalConfirm = () => {
     setShowModal(false);
     setModalDismissed(true);
-    setShowModal(false);
   };
 
   return (
-    <div className="flex min-h-screen flex-col items-center bg-b-primary px-4 pt-[10vh] sm:pt-[15vh]">
-      {showModal && (
-        <Modal
-          isOpen={showModal}
-          onClose={() => setShowModal(false)}
-          hasCloseButton={false}
-          icon="danger"
-          title="로그인이 필요한 페이지입니다."
-        >
-          <p className="text-center"></p>
-          <ModalFooter>
-            <Button
-              state="danger"
-              onClick={handleModalConfirm}
-            >
-              확인
-            </Button>
-          </ModalFooter>
-        </Modal>
-      )}
-      {modalDismissed && (
-        <>
-          <h2 className="text-center text-2xl font-medium lg:text-4xl">
-            로그인
-          </h2>
-          <div className="w-full max-w-[460px] space-y-12 pt-[4vh] sm:pt-[6vh]">
-            <div className="flex flex-col gap-6">
-              <LoginForm onSubmit={handleLoginSubmit} />
-              <div className="text-center font-medium">
-                아직 계정이 없으신가요?
-                <Link
-                  href="/signup"
-                  className="ml-2 text-primary underline hover:opacity-50"
-                >
-                  가입하기
-                </Link>
+    <Suspense fallback={<Loading />}>
+      <div className="flex min-h-screen flex-col items-center bg-b-primary px-4 pt-[10vh] sm:pt-[15vh]">
+        {showModal && (
+          <Modal
+            isOpen={showModal}
+            onClose={() => setShowModal(false)}
+            hasCloseButton={false}
+            icon="danger"
+            title="로그인이 필요한 페이지입니다."
+          >
+            <p className="text-center"></p>
+            <ModalFooter>
+              <Button
+                state="danger"
+                onClick={handleModalConfirm}
+              >
+                확인
+              </Button>
+            </ModalFooter>
+          </Modal>
+        )}
+        {modalDismissed && (
+          <>
+            <h2 className="text-center text-2xl font-medium lg:text-4xl">
+              로그인
+            </h2>
+            <div className="w-full max-w-[460px] space-y-12 pt-[4vh] sm:pt-[6vh]">
+              <div className="flex flex-col gap-6">
+                <LoginForm onSubmit={handleLoginSubmit} />
+                <div className="text-center font-medium">
+                  아직 계정이 없으신가요?
+                  <Link
+                    href="/signup"
+                    className="ml-2 text-primary underline hover:opacity-50"
+                  >
+                    가입하기
+                  </Link>
+                </div>
+              </div>
+              <div className="space-y-4">
+                <div className="flex w-full items-center gap-4">
+                  <div className="flex-1 border-t border-bd-primary opacity-10"></div>
+                  <span>OR</span>
+                  <div className="flex-1 border-t border-bd-primary opacity-10"></div>
+                </div>
+                <EasyLogin page="login" />
               </div>
             </div>
-            <div className="space-y-4">
-              <div className="flex w-full items-center gap-4">
-                <div className="flex-1 border-t border-bd-primary opacity-10"></div>
-                <span>OR</span>
-                <div className="flex-1 border-t border-bd-primary opacity-10"></div>
-              </div>
-              <EasyLogin page="login" />
-            </div>
-          </div>
-        </>
-      )}
-    </div>
+          </>
+        )}
+      </div>
+    </Suspense>
   );
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { Suspense, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 
@@ -14,7 +14,6 @@ import Button from '@components/Button';
 import useUserStore from '@stores/userStore';
 import LoginForm from '@app/login/LoginForm';
 import EasyLogin from '@app/login/EasyLogin';
-import Loading from '@components/Loading';
 
 export default function LoginPage() {
   const { setAccessToken, setRefreshToken, setUser } = useUserStore();
@@ -58,57 +57,55 @@ export default function LoginPage() {
   };
 
   return (
-    <Suspense fallback={<Loading />}>
-      <div className="flex min-h-screen flex-col items-center bg-b-primary px-4 pt-[10vh] sm:pt-[15vh]">
-        {showModal && (
-          <Modal
-            isOpen={showModal}
-            onClose={() => setShowModal(false)}
-            hasCloseButton={false}
-            icon="danger"
-            title="로그인이 필요한 페이지입니다."
-          >
-            <p className="text-center"></p>
-            <ModalFooter>
-              <Button
-                state="danger"
-                onClick={handleModalConfirm}
-              >
-                확인
-              </Button>
-            </ModalFooter>
-          </Modal>
-        )}
-        {modalDismissed && (
-          <>
-            <h2 className="text-center text-2xl font-medium lg:text-4xl">
-              로그인
-            </h2>
-            <div className="w-full max-w-[460px] space-y-12 pt-[4vh] sm:pt-[6vh]">
-              <div className="flex flex-col gap-6">
-                <LoginForm onSubmit={handleLoginSubmit} />
-                <div className="text-center font-medium">
-                  아직 계정이 없으신가요?
-                  <Link
-                    href="/signup"
-                    className="ml-2 text-primary underline hover:opacity-50"
-                  >
-                    가입하기
-                  </Link>
-                </div>
-              </div>
-              <div className="space-y-4">
-                <div className="flex w-full items-center gap-4">
-                  <div className="flex-1 border-t border-bd-primary opacity-10"></div>
-                  <span>OR</span>
-                  <div className="flex-1 border-t border-bd-primary opacity-10"></div>
-                </div>
-                <EasyLogin page="login" />
+    <div className="flex min-h-screen flex-col items-center bg-b-primary px-4 pt-[10vh] sm:pt-[15vh]">
+      {showModal && (
+        <Modal
+          isOpen={showModal}
+          onClose={() => setShowModal(false)}
+          hasCloseButton={false}
+          icon="danger"
+          title="로그인이 필요한 페이지입니다."
+        >
+          <p className="text-center"></p>
+          <ModalFooter>
+            <Button
+              state="danger"
+              onClick={handleModalConfirm}
+            >
+              확인
+            </Button>
+          </ModalFooter>
+        </Modal>
+      )}
+      {modalDismissed && (
+        <>
+          <h2 className="text-center text-2xl font-medium lg:text-4xl">
+            로그인
+          </h2>
+          <div className="w-full max-w-[460px] space-y-12 pt-[4vh] sm:pt-[6vh]">
+            <div className="flex flex-col gap-6">
+              <LoginForm onSubmit={handleLoginSubmit} />
+              <div className="text-center font-medium">
+                아직 계정이 없으신가요?
+                <Link
+                  href="/signup"
+                  className="ml-2 text-primary underline hover:opacity-50"
+                >
+                  가입하기
+                </Link>
               </div>
             </div>
-          </>
-        )}
-      </div>
-    </Suspense>
+            <div className="space-y-4">
+              <div className="flex w-full items-center gap-4">
+                <div className="flex-1 border-t border-bd-primary opacity-10"></div>
+                <span>OR</span>
+                <div className="flex-1 border-t border-bd-primary opacity-10"></div>
+              </div>
+              <EasyLogin page="login" />
+            </div>
+          </div>
+        </>
+      )}
+    </div>
   );
 }

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -72,9 +72,8 @@ export default function MyPage() {
     onSuccess: () => {
       clearUser();
       clearTeam();
-
       toast('회원 탈퇴가 정상 처리되었습니다.');
-
+      document.cookie = 'accessToken=; path=/; max-age=0';
       router.push('/');
     },
     onError: createErrorHandler({ prefixMessage: '회원 탈퇴 실패' }),

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // 회원가입 페이지나 정적 파일은 검증하지 않음
+  if (/\.(png|jpg|css|js|ico|svg)$/.test(pathname)) {
+    return NextResponse.next();
+  }
+
+  // 요청 쿠키에서 accessToken 추출
+  const token = request.cookies.get('accessToken')?.value;
+
+  // 로그인 페이지 접근 시, 이미 토큰이 있다면 메인 리다이렉트
+  if (
+    (pathname.startsWith('/login') || pathname.startsWith('/signup')) &&
+    token
+  ) {
+    const url = request.nextUrl.clone();
+    url.pathname = '/';
+    return NextResponse.redirect(url);
+  }
+
+  // 페이지 검증
+  // 로그인이 필요한 페이지인 경우, state와 redirect를 파라미터에 추가하여 로그인 페이지로 이동
+  const segments = pathname.split('/'); // ex: "/1829/tasklist" → ["", "1829", "tasklist"]
+  const firstSegment = segments[1];
+  if (
+    /^\d+$/.test(firstSegment) ||
+    pathname.startsWith('/mypage') ||
+    pathname.startsWith('/invitation') ||
+    pathname.startsWith('/myhistory') ||
+    pathname.startsWith('/boards/write')
+  ) {
+    if (!token) {
+      const url = request.nextUrl.clone();
+      url.pathname = '/login';
+      url.searchParams.set('state', 'login-required');
+      url.searchParams.set(
+        'redirect',
+        `${request.nextUrl.pathname}${request.nextUrl.search}`
+      );
+      return NextResponse.redirect(url);
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: '/:path*',
+};

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,8 +4,8 @@ import type { NextRequest } from 'next/server';
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
-  // 회원가입 페이지나 정적 파일은 검증하지 않음
-  if (/\.(png|jpg|css|js|ico|svg)$/.test(pathname)) {
+  // 정적 파일은 검증하지 않음
+  if (/\.(png|jpg|css|ts|ico|svg)$/.test(pathname)) {
     return NextResponse.next();
   }
 
@@ -26,10 +26,12 @@ export function middleware(request: NextRequest) {
   // 로그인이 필요한 페이지인 경우, state와 redirect를 파라미터에 추가하여 로그인 페이지로 이동
   const segments = pathname.split('/'); // ex: "/1829/tasklist" → ["", "1829", "tasklist"]
   const firstSegment = segments[1];
+
   if (
     /^\d+$/.test(firstSegment) ||
     pathname.startsWith('/mypage') ||
     pathname.startsWith('/invitation') ||
+    pathname.startsWith('/addteam') ||
     pathname.startsWith('/myhistory') ||
     pathname.startsWith('/boards/write')
   ) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,12 +4,11 @@ import type { NextRequest } from 'next/server';
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
-  // 정적 파일은 검증하지 않음
   if (/\.(png|jpg|css|ts|ico|svg)$/.test(pathname)) {
     return NextResponse.next();
   }
 
-  // 요청 쿠키에서 accessToken 추출
+  // 쿠키에서 accessToken 추출
   const token = request.cookies.get('accessToken')?.value;
 
   // 로그인 페이지 접근 시, 이미 토큰이 있다면 메인 리다이렉트
@@ -33,7 +32,8 @@ export function middleware(request: NextRequest) {
     pathname.startsWith('/invitation') ||
     pathname.startsWith('/addteam') ||
     pathname.startsWith('/myhistory') ||
-    pathname.startsWith('/boards/write')
+    pathname.startsWith('/boards/write') ||
+    pathname.startsWith('/noteam')
   ) {
     if (!token) {
       const url = request.nextUrl.clone();


### PR DESCRIPTION
## 📌 Related Issue
- Closed #157 

## 🧾 작업 사항
- 페이지 접근 시 경로로 로그인 여부를 확인하는 미들웨어 추가.
- 로그인이 필요한 경로
  - `/mypage`
  - `/invitation`
  - `/myhistory`
  - `/addteam`
  - `/{teamId}/*`
  - `/boards/write`
- 로그인이 필요 없는 경로
  - `/`
  - `/login`
  - `/signup`
  - `/boards`
  - `/boards/{articleId}`
- 로그인하면 접근할 수 없는 경로
  - `/login`
  - `/signup`
## 📚 리뷰 포인트
- 위 경로들을 기준으로 학수님이 제안해주신 `middleware.ts`를 추가했습니다.
- api요청을 전송하기 전 쿠키의 토큰 유무를 확인하고, 토큰이 없다면 요청 자체를 보내지 않고 동작을 처리하는 next 내장기능입니다.
- 로그인 하지 않고 로그인이 필요한 페이지로 직접 접근 시, 로그인 페이지로 리다이렉트 시키며 '로그인이 필요합니다' 하는 모달을 확인 후 로그인 폼이 나타납니다.
- 이 때 로그인을 성공하면 이전에 접근하려 했던 페이지로 이동합니다.
- 미들웨어에서 로그인 여부를 검증하므로, 팀 페이지와 자유 게시판 수정/작성에서 로그인 여부를 검증하는 로직을 수정 및 제거했습니다.

---

- 로그인한 유저의 권한을 검증하는 팀 페이지의 하위 페이지, 자유게시글 수정 페이지 등에 구현된 멤버 확인 로직은 유지되어야 합니다.
- 원래는 서버에서 `HTTPOnly`로 설정된 쿠키를 로그인 응답에서 추가해주어야 합니다. 하지만 현재 서버는 그렇게 해주지 않아서, 로그인 시 클라이언트에서 쿠키에 `accessToken` 을 추가했습니다. 실제 서비스에서는 `HTTPOnly`가 아닌 쿠키에 토큰을 저장하는 것은 보안 상 적용할 수 없는 방법입니다.

## 📷 Screenshot/GIF
![image](https://github.com/user-attachments/assets/b3ee8b02-41ea-4726-88a9-c3ffd18d2dfd)
![image](https://github.com/user-attachments/assets/7a3d86c4-5f1f-4d32-a66f-9bffd8a4fd5b)

