### PR TITLE
Refactor/162  비밀번호 재설정 리팩토링

### DIFF
--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import ResetPasswordForm from '@/app/reset-password/ResetPasswordForm';
+
 import { useMutation } from '@tanstack/react-query';
-import axios from 'axios';
-import { patchUserResetPassword } from '../api/user.api';
+
+import { patchUserResetPassword } from '@api/user.api';
+import { createErrorHandler } from '@utils/createErrorHandler';
+import ResetPasswordForm from '@app/reset-password/ResetPasswordForm';
 
 export default function ResetPasswordPage() {
   const [token, setToken] = useState('');
@@ -27,16 +29,7 @@ export default function ResetPasswordPage() {
       alert('비밀번호가 성공적으로 변경되었습니다!');
       window.location.href = '/login';
     },
-    onError: (error) => {
-      if (axios.isAxiosError(error) && error.response) {
-        const errorMessage =
-          error.response.data.message ||
-          '비밀번호 재설정 중 오류가 발생했습니다.';
-        alert(`비밀번호 재설정 실패: ${errorMessage}`);
-      } else {
-        alert('예기치 못한 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
-      }
-    },
+    onError: createErrorHandler({ prefixMessage: '비밀번호 재설정 실패' }),
   });
 
   const handleResetPasswordSubmit = (formData: {

--- a/app/signup/SignupForm.tsx
+++ b/app/signup/SignupForm.tsx
@@ -29,6 +29,12 @@ export default function SignupForm({
 }: SignupFormProps) {
   const [formData, setFormData] = useState(initialFormData);
   const [isValidated, setIsValidated] = useState(false);
+  const [errors, setErrors] = useState({
+    nickname: '',
+    email: '',
+    password: '',
+    confirmPassword: '',
+  });
 
   const validateForm = useCallback(() => {
     const newErrors = {
@@ -39,6 +45,7 @@ export default function SignupForm({
         validateConfirmPassword(formData.confirmPassword.trim()) || '',
     };
 
+    setErrors(newErrors);
     setIsValidated(!Object.values(newErrors).some((error) => error));
   }, [formData]);
 
@@ -111,6 +118,31 @@ export default function SignupForm({
             isPassword={true}
           />
         </div>
+      </div>
+      <div className="space-y-6">
+        <Button
+          type="submit"
+          styleType="solid"
+          size="py-3.5 w-full text-md"
+          state="default"
+          disabled={!isValidated}
+        >
+          회원가입
+        </Button>
+        {!isValidated && (
+          <div className="mt-2 text-sm text-danger">
+            {Object.values(formData).every((val) => val.trim() !== '') &&
+              !isValidated && (
+                <div className="mt-2 text-sm text-danger">
+                  {Object.keys(errors)
+                    .filter((key) => errors[key as keyof typeof errors])
+                    .map((key, idx) => (
+                      <p key={idx}>{errors[key as keyof typeof errors]}</p>
+                    ))}
+                </div>
+              )}
+          </div>
+        )}
         <Link
           href="/login"
           className="block w-fit cursor-pointer place-self-end text-right text-md text-emerald-500 underline hover:opacity-50 sm:text-lg"
@@ -118,15 +150,6 @@ export default function SignupForm({
           로그인 페이지로
         </Link>
       </div>
-      <Button
-        type="submit"
-        styleType="solid"
-        size="py-3.5 w-full text-md"
-        state="default"
-        disabled={!isValidated}
-      >
-        회원가입
-      </Button>
     </form>
   );
 }

--- a/app/signup/SignupForm.tsx
+++ b/app/signup/SignupForm.tsx
@@ -131,16 +131,15 @@ export default function SignupForm({
         </Button>
         {!isValidated && (
           <div className="mt-2 text-sm text-danger">
-            {Object.values(formData).every((val) => val.trim() !== '') &&
-              !isValidated && (
-                <div className="mt-2 text-sm text-danger">
-                  {Object.keys(errors)
-                    .filter((key) => errors[key as keyof typeof errors])
-                    .map((key, idx) => (
-                      <p key={idx}>{errors[key as keyof typeof errors]}</p>
-                    ))}
-                </div>
-              )}
+            {Object.values(formData).every((val) => val.trim() !== '') && (
+              <div className="mt-2 text-sm text-danger">
+                {Object.keys(errors)
+                  .filter((key) => errors[key as keyof typeof errors])
+                  .map((key, idx) => (
+                    <p key={idx}>{errors[key as keyof typeof errors]}</p>
+                  ))}
+              </div>
+            )}
           </div>
         )}
         <Link


### PR DESCRIPTION
## 📌 Related Issue
- Closed #162 

## 🧾 작업 사항
- 비밀번호 재설정 페이지 컨벤션 반영
- 회원가입 폼 전체 검사 에러메시지 추가


## 📚 리뷰 포인트
- 기존 문제는 비밀번호와 비밀번호 확인을 모두 정상적으로 입력한 후, 다시 비밀번호 값을 바꾸게 되면 회원가입 버튼은 비활성화되지만 에러메시지는 나오지 않아 어떤 것 때문에 비활성화 되는지 사용자에게 혼란을 줄 수 있다는 점이었습니다.
- 이를 해결하기 위해 `InputField` 컴포넌트를 수정하여 `onChange`에서 동작하는 `validator`도 추가해봤지만, 다른 필드 값에 대해서는 에러메시지를 조작하기 어려웠습니다.
- 선택한 방법은 입력 폼에 모든 값이 입력되었을 때, 버튼 활성화 검사를 시행할 때 에러가 있다면 그 메시지를 띄우는 방법입니다.
- 하지만 이 방식을 선택했을 때도, 비밀번호 값을 서로 번갈아가며 바꾸다 보면 에러 메시지가 남아있는데 회원가입 버튼이 활성화되는 경우가 발생합니다.

--- 

- 작업 중 추가로 생각한 방법으로 각각의 필드에 에러메시지를 띄우지 않고, 폼 전체의 에러메시지를 `onChange`로 검증하여 회원가입 버튼의 활성화와 에러의 유무를 정확히 일치시키는 방법이 있습니다. (3번째 이미지)
- 이 경우엔 `onChange`로 유효성을 검사하며 각각의 필드에 값이 입력되었다면 해당 필드의 에러를 버튼 하단에 출력합니다.
- 우선 현재 PR은 첫 번째로 말씀드린 방법을 적용한 PR입니다. 다른 방법이 더 나은 것 같다고 생각하시면 피드백 부탁드립니다.(1, 2번째 이미지)

## 📷 Screenshot/GIF
- 현재 PR: 정상 입력 후 비밀번호 값을 변경
![스크린샷 2025-02-17 190212](https://github.com/user-attachments/assets/53fb18e0-6e9a-41e7-a23c-5feba9eb2886)

- 위 케이스에서 비밀번호 확인을 다시 클릭한 뒤 값을 수정하지 않고 `onBlur` 이벤트가 발생한 경우
![스크린샷 2025-02-17 190341](https://github.com/user-attachments/assets/48d574c2-1a9c-4beb-a31e-35200d186260)

- 모든 유효성 검사를 한 번에 진행하여 감지된 에러메시지를 모두 띄우는 경우
![image](https://github.com/user-attachments/assets/88bbf685-9c87-4878-85b8-12f7eb724508)

