### PR TITLE
Fix/159  카카오브라우저 안내 오류 해결

### DIFF
--- a/app/components/Gnb/ProfileDropDown.tsx
+++ b/app/components/Gnb/ProfileDropDown.tsx
@@ -28,6 +28,7 @@ export default function ProfileDropDown({ user }: ProfileDropDownProps) {
     clearUser();
     clearTeam();
     document.cookie = 'accessToken=; path=/; max-age=0';
+    localStorage.removeItem('kakao_state');
 
     if (isGoogleLogin) {
       signOut();

--- a/app/oauth/kakao/page.tsx
+++ b/app/oauth/kakao/page.tsx
@@ -57,7 +57,7 @@ const KakaoCallback = () => {
 
     if (!code) {
       redirectWithMessage(
-        '⚠️ 인가 코드가 없습니다. 카카오톡 간편 로그인을 다시 진행해주세요.'
+        '카카오톡 인증에 실패했습니다. 정상적인 경로로 다시 접근해주세요.'
       );
 
       return;
@@ -88,7 +88,7 @@ const KakaoCallback = () => {
 
     if (!receivedState || receivedState !== storedStateObj?.value) {
       redirectWithMessage(
-        '⚠️ CSRF 공격이 감지되었습니다. 카카오톡 간편 로그인을 다시 진행해주세요.'
+        '일시적인 오류가 발생했습니다. 카카오톡 간편 로그인을 다시 진행해주세요.'
       );
 
       return;

--- a/app/oauth/kakao/page.tsx
+++ b/app/oauth/kakao/page.tsx
@@ -63,7 +63,7 @@ const KakaoCallback = () => {
       return;
     }
 
-    const validDuration = 3 * 60 * 1000; // 3분
+    const validDuration = 15 * 1000; // 15초
     let storedStateObj: { value: string; timestamp: number } | null = null;
 
     try {

--- a/app/oauth/kakao/page.tsx
+++ b/app/oauth/kakao/page.tsx
@@ -66,13 +66,13 @@ const KakaoCallback = () => {
     const validDuration = 3 * 60 * 1000; // 3분
     let storedStateObj: { value: string; timestamp: number } | null = null;
 
-    if (isKakaoBrowser) {
-      try {
-        storedStateObj = storedState ? JSON.parse(storedState) : null;
-      } catch {
-        storedStateObj = null;
-      }
+    try {
+      storedStateObj = storedState ? JSON.parse(storedState) : null;
+    } catch {
+      storedStateObj = null;
+    }
 
+    if (isKakaoBrowser) {
       if (
         !storedStateObj ||
         Date.now() - storedStateObj.timestamp > validDuration

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -18,7 +18,7 @@ export default function SignupPage() {
   const signupMutation = useMutation({
     mutationFn: postAuthSignUp,
     onSuccess: () => {
-      toast('회원가입에 성공했습니다!');
+      toast.success('회원가입에 성공했습니다!');
       router.push('/login');
     },
     onError: createErrorHandler({ prefixMessage: '회원가입 실패' }),


### PR DESCRIPTION
## 📌 Related Issue
- #159

## 🧾 작업 사항
- 카카오 브라우저 기준으로 작업 하다가 웹 인증 과정이 제대로 되지 않던 오류 수정
- 로그인 로직에 `state`삭제 로직 추가

## 📚 리뷰 포인트
- 카카오 브라우저 기준으로 코드를 수정하다가, 웹에서 카카오 로그인이 잘 이뤄지지 않던 부분을 수정했습니다.
- `state` 검사 유효 시간을 3분에서 15초로 수정했습니다.
- 이제 웹, 모바일 웹(시크릿모드), 모바일 카카오 브라우저 모두 카카오 로그인이 정상적으로 동작해야합니다.
