### PR TITLE
chore: actions/cache 버전업

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: 18
       - name: Cache Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
## 📌 Related Issue
- Closed #179 

## 🧾 작업 사항
- 크로마틱 자동 배보 액션 설정 `actions/cashe@v2` -> `actions/cashe@v3` 버전업

## 📚 리뷰 포인트
- `actions/cashe`의 `v2`를 깃허브에서 지원 중단하여, `v3`로 수정