### PR TITLE
리스트페이지 탈퇴한 회원 할 일 상세 접근 시 에러 처리

### DIFF
--- a/app/[teamid]/tasklist/modals/DeletedTaskModal.tsx
+++ b/app/[teamid]/tasklist/modals/DeletedTaskModal.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import Modal, { ModalFooter } from '@components/Modal';
+import Button from '@components/Button';
+
+interface DeletedTaskModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onDelete: () => void;
+}
+
+export default function DeletedTaskModal({
+  isOpen,
+  onClose,
+  onDelete,
+}: DeletedTaskModalProps) {
+  return (
+    <Modal
+      isOpen={isOpen}
+      title="탈퇴한 회원의 게시글입니다."
+      onClose={onClose}
+      hasCloseButton={false}
+      icon="danger"
+    >
+      <p className="mt-5 text-center text-md font-semibold text-t-default">
+        삭제 후 목록 페이지로 돌아갑니다.
+      </p>
+      <ModalFooter>
+        <Button
+          state="danger"
+          onClick={onDelete}
+        >
+          확인
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+}

--- a/app/[teamid]/tasklist/task-detail/TaskDetail.tsx
+++ b/app/[teamid]/tasklist/task-detail/TaskDetail.tsx
@@ -17,6 +17,7 @@ import EditModal from '../modals/EditModal';
 import TaskDetailHeader from './TaskDetailHeader';
 import TaskComment from './TaskComment';
 import CheckButton from './CheckButton';
+import DeletedTaskModal from '../modals/DeletedTaskModal';
 
 interface TaskDetailProps {
   taskId: number;
@@ -184,6 +185,16 @@ export default function TaskDetail({
       <div className="flex min-h-[60vh] items-center justify-center">
         <Loading />
       </div>
+    );
+  }
+
+  if (!task || !task.writer) {
+    return (
+      <DeletedTaskModal
+        isOpen={true}
+        onClose={onClose}
+        onDelete={handleDelete}
+      />
     );
   }
 


### PR DESCRIPTION
## 📌 Related Issue
- Closed #182 

## 🧾 작업 사항
- 리스트 페이지에서 탈퇴한 회원이 작성했던 할 일에 접근 시 발생하던 에러 개선

## 📚 리뷰 포인트
- 회원 탈퇴 시 작성했던 할 일을 전부 삭제하는건 힘들어도 지금처럼 탈퇴한 회원 게시글의 상세페이지에 접근 했을 때 탈퇴한 회원의 게시글이라는 걸 보여줄 것이라면 확인 버튼을 누를 때 삭제 함수를 전달해주기만 하면 되는거라서 추가해봤습니다.
- 확인 버튼을 누르면 해당 할 일이 삭제되는 것을 확인했습니다.
- 회원 탈퇴한 게시글 반응형에서 살짝 스크롤이 생기거나 밀리는 구간이 있긴한데 탈퇴한 회원 모달 하나를 위해서 상세페이지 자체를 뜯어고쳐야 할 수도 있어서 이 부분은 큰 영향을 끼치는건 아니라 냅두겠습니다...ㅎㅎ

## 📷 Screenshot/GIF
- ![image](https://github.com/user-attachments/assets/fb673497-f24f-45c4-a9dd-a9164244d053)

