### PR TITLE
🔨 refactor: 스토리북, 이미지 컴포넌트 수정

### DIFF
--- a/app/components/ImageUpload.tsx
+++ b/app/components/ImageUpload.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { postImagesUpload } from '@/app/api/image.api';
 import { toast } from 'react-toastify';
 
@@ -22,6 +22,18 @@ function ImageUpload({
 }: FileUploadProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [isMobile, setIsMobile] = useState<boolean>(false);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth <= 640);
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
 
   const handleFileChange = async (
     event: React.ChangeEvent<HTMLInputElement>
@@ -51,6 +63,8 @@ function ImageUpload({
       fileInputRef.current.click();
     }
   };
+
+  const imageSize = isMobile ? 160 : 234;
 
   return (
     <div className="flex flex-col items-center">
@@ -126,10 +140,25 @@ function ImageUpload({
       ) : (
         // Square 영역
         <div
-          className="relative flex h-[160px] w-[160px] cursor-pointer flex-col items-center justify-center overflow-hidden rounded-lg border-[3px] border-gray-200/10 bg-b-primary sm:h-[240px] sm:w-[240px]"
+          className="relative flex cursor-pointer flex-col items-center justify-center overflow-hidden rounded-lg border-[3px] border-gray-200/10 bg-b-primary"
+          style={{
+            width: `${imageSize}px`,
+            height: `${imageSize}px`,
+          }}
           onClick={triggerFileInput}
         >
-          {!previewUrl && !url ? (
+          {url || previewUrl ? (
+            <Image
+              src={previewUrl || url}
+              alt="업로드된 이미지 미리보기"
+              fill
+              style={{
+                objectFit: 'cover',
+                width: '100%',
+                height: '100%',
+              }}
+            />
+          ) : (
             <>
               <Image
                 src="/images/icons/ic_plus.svg"
@@ -142,14 +171,6 @@ function ImageUpload({
                 이미지 등록
               </div>
             </>
-          ) : (
-            <Image
-              src={previewUrl || url}
-              alt="업로드된 이미지 미리보기"
-              width={160}
-              height={160}
-              className="absolute inset-0 h-full w-full object-cover sm:h-[240px] sm:w-[240px]"
-            />
           )}
         </div>
       )}

--- a/stories/ImageUpload.stories.tsx
+++ b/stories/ImageUpload.stories.tsx
@@ -1,6 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import ImageUpload from '@/app/components/ImageUpload';
 
+const MOCK_IMAGE_URL =
+  'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Coworkers/user/1314/images.jpg';
+
 const meta: Meta<typeof ImageUpload> = {
   title: 'Components/ImageUpload',
   component: ImageUpload,
@@ -71,9 +74,10 @@ export const Square: Story = {
 };
 
 // Circle with Preview
-export const CircleWithPreview: Story = {
+export const CircleWithMockPreview: Story = {
   args: {
     variant: 'circle',
+    url: MOCK_IMAGE_URL,
     onUploadSuccess: (url: string) => console.log('업로드 성공:', url),
     onUploadError: (error: Error) => console.error('업로드 실패:', error),
   },
@@ -85,9 +89,10 @@ export const CircleWithPreview: Story = {
 };
 
 // Square with Preview
-export const SquareWithPreview: Story = {
+export const SquareWithMockPreview: Story = {
   args: {
     variant: 'square',
+    url: MOCK_IMAGE_URL,
     onUploadSuccess: (url: string) => console.log('업로드 성공:', url),
     onUploadError: (error: Error) => console.error('업로드 실패:', error),
   },


### PR DESCRIPTION
## 📌 Related Issue
- Closed #186 

## 🧾 작업 사항
- 이미지 업로드 스토리북에 이미지 미리보기 ui 목차 추가

## 📚 리뷰 포인트
- ui 확인용으로 목데이터를 추가해 확인할 수 있게 수정했습니다.
- Square 형태가 다른 페이지에서 사용할 때는 잘 작동했는데 스토리북에서만 이미지 미리보기가 영역에 꽉 차지 않는 문제가 발생하더라고요,,, 아마 어떤 속성이 스토리북과 충돌이 있는 거 같은데 찾아봐도 잘 모르겠어서
기존 이미지 컴포넌트의 Square 반응형 부분만 약간 수정했습니다.
## 📷 Screenshot/GIF
![image](https://github.com/user-attachments/assets/0bab1a11-f595-47b7-b179-ea707152f466)

